### PR TITLE
Add automated weekly issue/PR maintenance triage (GitHub Actions)

### DIFF
--- a/.github/workflows/maintenance-triage.yml
+++ b/.github/workflows/maintenance-triage.yml
@@ -1,0 +1,313 @@
+name: Maintenance triage
+
+on:
+  schedule:
+    - cron: "0 14 * * 1" # Mondays 14:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run stale/closure triage
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const now = Date.now();
+            const DAY_MS = 24 * 60 * 60 * 1000;
+
+            const thresholds = {
+              warnDays: 30,
+              closeDays: 60,
+            };
+
+            const policyLabels = [
+              { name: 'stale-pr', color: 'FBCA04', description: 'PR has no activity for the stale threshold and may be closed.' },
+              { name: 'blocked-needs-author', color: 'D93F0B', description: 'Waiting on author response/changes before maintainer action.' },
+              { name: 'superseded', color: '5319E7', description: 'Replaced by a newer issue or PR.' },
+              { name: 'cannot-reproduce', color: 'BFD4F2', description: 'Maintainers cannot reproduce the reported behavior.' },
+              { name: 'needs-design', color: '0E8A16', description: 'Requires design/product decision before implementation.' },
+              { name: 'close-candidate', color: 'C2E0C6', description: 'Maintainers marked this PR as a closure candidate.' },
+              { name: 'stale-warning', color: 'F9D0C4', description: 'Warning issued before stale auto-close.' },
+            ];
+
+            async function ensureLabels() {
+              const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+                owner,
+                repo,
+                per_page: 100,
+              });
+              const existingNames = new Set(existing.map((l) => l.name));
+              for (const label of policyLabels) {
+                if (existingNames.has(label.name)) continue;
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
+            }
+
+            function ageDays(ts) {
+              return Math.floor((now - new Date(ts).getTime()) / DAY_MS);
+            }
+
+            function hasAnyLabel(item, names) {
+              const set = new Set(item.labels.map((l) => l.name));
+              return names.some((name) => set.has(name));
+            }
+
+            async function findMergedLinkedPr(issueNumber) {
+              const timeline = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              for (const ev of timeline) {
+                const src = ev.source;
+                if (!src || src.type !== 'issue') continue;
+                const maybePr = src.issue?.pull_request;
+                if (!maybePr) continue;
+
+                const prNumber = src.issue.number;
+                const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+                if (pr.data.merged_at) {
+                  return prNumber;
+                }
+              }
+              return null;
+            }
+
+            async function closeCandidatePRs(report) {
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+
+              for (const pr of prs) {
+                const issue = await github.rest.issues.get({ owner, repo, issue_number: pr.number });
+                if (!hasAnyLabel(issue.data, ['close-candidate'])) continue;
+
+                const dependencyData = await github.graphql(
+                  `query($owner: String!, $repo: String!, $number: Int!) {
+                     repository(owner: $owner, name: $repo) {
+                       pullRequest(number: $number) {
+                         milestone { state title }
+                         closingIssuesReferences(first: 20, states: OPEN) {
+                           nodes { number title }
+                         }
+                       }
+                     }
+                   }`,
+                  { owner, repo, number: pr.number }
+                );
+
+                const prNode = dependencyData.repository.pullRequest;
+                const hasOpenMilestone = prNode.milestone && prNode.milestone.state === 'OPEN';
+                const openLinkedIssues = prNode.closingIssuesReferences.nodes || [];
+                if (hasOpenMilestone || openLinkedIssues.length > 0) {
+                  report.blocked.push(`#${pr.number} blocked by open dependency`);
+                  continue;
+                }
+
+                const issueLabels = issue.data.labels.map((l) => l.name);
+                const closureLabel = issueLabels.includes('superseded')
+                  ? 'superseded'
+                  : issueLabels.includes('blocked-needs-author')
+                    ? 'blocked-needs-author'
+                    : 'stale-pr';
+                const closeReason = issueLabels.includes('superseded') ? 'completed' : 'not_planned';
+
+                const unblockConditions = [
+                  '1) Re-open with a fresh branch that rebases cleanly on `main`.',
+                  '2) Resolve all review feedback and CI failures.',
+                  '3) Remove or resolve any `blocked-needs-author` / `needs-design` blockers with maintainer confirmation.',
+                ].join('\n');
+
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: `Final maintainer notice: this pull request is being closed under triage policy.\n\nTo unblock and request reopen, satisfy all conditions exactly:\n${unblockConditions}`,
+                });
+
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: [closureLabel],
+                });
+
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  state: 'closed',
+                  state_reason: closeReason,
+                });
+
+                report.prClosed.push(`#${pr.number} (${closureLabel})`);
+              }
+            }
+
+            async function triageIssues(report) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              });
+
+              for (const issue of issues) {
+                if (issue.pull_request) continue;
+
+                const labels = issue.labels.map((l) => l.name);
+
+                if (labels.includes('duplicate') || labels.includes('superseded')) {
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                    state_reason: 'not_planned',
+                  });
+                  report.issueClosed.push(`#${issue.number} (deduplicated)`);
+                  continue;
+                }
+
+                const mergedPr = await findMergedLinkedPr(issue.number);
+                if (mergedPr) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: `Automatically closing as solved by merged PR #${mergedPr}.`,
+                  });
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                    state_reason: 'completed',
+                  });
+                  report.issueClosed.push(`#${issue.number} (solved by #${mergedPr})`);
+                  continue;
+                }
+
+                const inactiveDays = ageDays(issue.updated_at);
+                if (inactiveDays >= thresholds.closeDays && labels.includes('stale-warning')) {
+                  await github.rest.issues.update({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                    state_reason: 'not_planned',
+                  });
+                  report.issueClosed.push(`#${issue.number} (stale)`);
+                  continue;
+                }
+
+                if (inactiveDays >= thresholds.warnDays && !labels.includes('stale-warning')) {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    body: `This issue has been inactive for ${inactiveDays} days. It will be closed after ${thresholds.closeDays} days of inactivity unless updated with next steps, owner, or a linked PR.`,
+                  });
+                  await github.rest.issues.addLabels({
+                    owner,
+                    repo,
+                    issue_number: issue.number,
+                    labels: ['stale-warning'],
+                  });
+                  report.warned.push(`#${issue.number}`);
+                }
+
+                if (labels.includes('needs-design') || labels.includes('blocked-needs-author')) {
+                  report.blocked.push(`#${issue.number} needs maintainer decision`);
+                }
+              }
+            }
+
+            async function collectWeeklyMetrics(report) {
+              const since = new Date(now - 7 * DAY_MS).toISOString();
+              const [openIssues, openPRs, closedIssuesRecent, closedPRsRecent] = await Promise.all([
+                github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'open', per_page: 100 }),
+                github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 }),
+                github.paginate(github.rest.issues.listForRepo, { owner, repo, state: 'closed', since, per_page: 100 }),
+                github.paginate(github.rest.pulls.list, { owner, repo, state: 'closed', sort: 'updated', direction: 'desc', per_page: 100 }),
+              ]);
+
+              const closedIssuesWeek = closedIssuesRecent.filter((i) => !i.pull_request && new Date(i.closed_at || 0).getTime() >= now - 7 * DAY_MS).length;
+              const closedPrWeek = closedPRsRecent.filter((p) => new Date(p.closed_at || 0).getTime() >= now - 7 * DAY_MS).length;
+
+              const recentlyUpdated = await github.paginate(github.rest.issues.listForRepo, {
+                owner,
+                repo,
+                state: 'all',
+                since,
+                per_page: 100,
+              });
+              let reopenedWeek = 0;
+              for (const item of recentlyUpdated.slice(0, 50)) {
+                const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  per_page: 100,
+                });
+                reopenedWeek += events.filter((ev) => ev.event === 'reopened' && new Date(ev.created_at).getTime() >= now - 7 * DAY_MS).length;
+              }
+
+              report.counts = {
+                openIssues: openIssues.filter((i) => !i.pull_request).length,
+                openPRs: openPRs.length,
+                blocked: report.blocked.length,
+                newlyClosedIssues: closedIssuesWeek,
+                newlyClosedPRs: closedPrWeek,
+                reopened: reopenedWeek,
+              };
+            }
+
+            const report = {
+              prClosed: [],
+              issueClosed: [],
+              warned: [],
+              blocked: [],
+              counts: {},
+            };
+
+            await ensureLabels();
+            await closeCandidatePRs(report);
+            await triageIssues(report);
+            await collectWeeklyMetrics(report);
+
+            const lines = [
+              `## Weekly triage report`,
+              `- Open issues: ${report.counts.openIssues}`,
+              `- Open PRs: ${report.counts.openPRs}`,
+              `- Newly closed issues (7d): ${report.counts.newlyClosedIssues}`,
+              `- Newly closed PRs (7d): ${report.counts.newlyClosedPRs}`,
+              `- Reopened items (7d): ${report.counts.reopened}`,
+              `- Blocked items needing maintainer decision: ${report.counts.blocked}`,
+              '',
+              `### PRs closed this run (${report.prClosed.length})`,
+              ...(report.prClosed.length ? report.prClosed : ['- none']),
+              '',
+              `### Issues closed this run (${report.issueClosed.length})`,
+              ...(report.issueClosed.length ? report.issueClosed : ['- none']),
+              '',
+              `### Stale warnings issued (${report.warned.length})`,
+              ...(report.warned.length ? report.warned : ['- none']),
+              '',
+              `### Blocked items`,
+              ...(report.blocked.length ? report.blocked : ['- none']),
+            ];
+
+            await core.summary.addRaw(lines.join('\n')).write();

--- a/docs/GITHUB_TRIAGE_POLICY.md
+++ b/docs/GITHUB_TRIAGE_POLICY.md
@@ -1,0 +1,50 @@
+# GitHub Triage and Closure Policy
+
+This repository uses an automated weekly triage workflow to keep issues and pull requests healthy and actionable.
+
+## Labels managed by policy
+
+- `stale-pr`: Pull request has exceeded stale inactivity threshold.
+- `blocked-needs-author`: Maintainer is waiting on author action.
+- `superseded`: Replaced by a newer issue or pull request.
+- `cannot-reproduce`: Maintainers could not reproduce the report.
+- `needs-design`: Requires product/design decision.
+- `close-candidate`: Explicit maintainer signal that PR should be evaluated for closure.
+- `stale-warning`: Warning posted before stale issue closure.
+
+## Time thresholds
+
+- **Warning threshold:** 30 days of no activity.
+- **Closure threshold:** 60 days of no activity (after warning grace period).
+
+## Pull request closure flow (`close-candidate`)
+
+For open PRs labeled `close-candidate`, automation performs this gate:
+
+1. Verify there is no active dependency:
+   - no open linked closing issue references,
+   - no open milestone.
+2. If dependency-free, post a final maintainer comment with exact unblock conditions:
+   - rebase cleanly on `main`,
+   - resolve CI and review feedback,
+   - resolve blocker labels with maintainer confirmation.
+3. Apply closure label and close:
+   - use `superseded` when that label exists,
+   - otherwise use policy fallback labels and close as `not_planned`.
+
+## Issue triage flow
+
+- **De-duplication:** close issues labeled `duplicate` or `superseded`.
+- **Solved-by-PR:** close issue automatically when timeline shows a merged linked PR.
+- **Stale process:**
+  1. after 30 inactive days, post warning + add `stale-warning`;
+  2. after 60 inactive days with warning still present, close as `not_planned`.
+
+## Weekly report
+
+Every weekly run emits a triage report with:
+
+- count by status (open issues, open PRs),
+- newly closed items in the last 7 days,
+- reopened items in the last 7 days,
+- blocked items that need maintainer decision.


### PR DESCRIPTION
### Motivation

- Reduce maintainer load and keep the repository actionable by automating stale/closure triage for PRs and issues on a regular cadence. 
- Enforce a clear closure policy with standardized labels and time thresholds so maintainers and contributors have predictable unblock paths. 
- Automatically handle routine flows (deduplication, solved-by-PR closing, stale warnings) and surface items that require human decision.

### Description

- Add a new scheduled GitHub Actions workflow ` .github/workflows/maintenance-triage.yml` that runs weekly (and via manual dispatch) with `issues` and `pull-requests` write permissions. 
- Ensure and manage policy labels (`stale-pr`, `blocked-needs-author`, `superseded`, `cannot-reproduce`, `needs-design`, plus operational labels `close-candidate` and `stale-warning`). 
- Implement `close-candidate` PR processing that verifies no open milestone or open linked closing issues via a GraphQL query, posts a final maintainer comment with exact unblock conditions, applies a closure label, and closes the PR with a policy-aligned reason. 
- Implement issue triage to close duplicates/superseded issues, auto-close issues solved by a merged linked PR, post a stale warning at 30 days and close after 60 days if unchanged, and emit a weekly triage report to the Actions job summary using `core.summary.addRaw`.
- Add documentation `docs/GITHUB_TRIAGE_POLICY.md` describing labels, thresholds, PR and issue flows, and the weekly report format.

### Testing

- Ran `python3 -m pytest -q tests/test_github_copilot_mcp.py`, which completed successfully (`21 passed`).
- Attempted YAML parsing validation but `PyYAML` was not available in the environment, so automated YAML load could not be executed (`PyYAML` missing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa6ea6e08832eaf68dd3ab7bf9403)