### PR TITLE
Fix _MissingPackage sentinel for optional numpy/requests imports

### DIFF
--- a/core/memory_types.py
+++ b/core/memory_types.py
@@ -5,10 +5,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Protocol
+
+
+class _MissingPackage:
+    """Placeholder for optional dependencies that are not installed."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def __getattr__(self, attr: str) -> None:
+        raise ImportError(f"Optional dependency '{self._name}' is required for this operation.")
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        raise ImportError(f"Optional dependency '{self._name}' is required for this operation.")
+
+
 try:
-    import numpy as np
-except ImportError:
-    np = None  # type: ignore[assignment]
+    import numpy as np  # type: ignore
+except ImportError:  # pragma: no cover - exercised via optional-deps tests
+    np = _MissingPackage("numpy")  # type: ignore
 
 @dataclass
 class MemoryRecord:

--- a/core/model_adapter.py
+++ b/core/model_adapter.py
@@ -5,16 +5,34 @@ import hashlib
 import os
 import shlex
 import subprocess
-import requests
 import json
 import time
 from pathlib import Path
 from typing import Any, List
 
+
+class _MissingPackage:
+    """Placeholder for optional dependencies that are not installed."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def __getattr__(self, attr: str) -> None:
+        raise ImportError(f"Optional dependency '{self._name}' is required for this operation.")
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        raise ImportError(f"Optional dependency '{self._name}' is required for this operation.")
+
+
 try:
-    import numpy as np
-except ImportError:
-    np = None  # type: ignore[assignment]
+    import requests  # type: ignore
+except ImportError:  # pragma: no cover - exercised via optional-deps tests
+    requests = _MissingPackage("requests")  # type: ignore
+
+try:
+    import numpy as np  # type: ignore
+except ImportError:  # pragma: no cover - exercised via optional-deps tests
+    np = _MissingPackage("numpy")  # type: ignore
 
 from core.logging_utils import log_json # Import log_json
 from core.file_tools import _aura_safe_loads # Import _aura_safe_loads

--- a/core/vector_store.py
+++ b/core/vector_store.py
@@ -1,13 +1,30 @@
+from __future__ import annotations
+
 import json
 import time
 import uuid
 import hashlib
-try:
-    import numpy as np
-except ImportError:
-    np = None  # type: ignore[assignment]
 import sqlite3
 from typing import List, Dict, Any, Union
+
+
+class _MissingPackage:
+    """Placeholder for optional dependencies that are not installed."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def __getattr__(self, attr: str) -> None:
+        raise ImportError(f"Optional dependency '{self._name}' is required for this operation.")
+
+    def __call__(self, *args: object, **kwargs: object) -> None:
+        raise ImportError(f"Optional dependency '{self._name}' is required for this operation.")
+
+
+try:
+    import numpy as np  # type: ignore
+except ImportError:  # pragma: no cover - exercised via optional-deps tests
+    np = _MissingPackage("numpy")  # type: ignore
 from core.logging_utils import log_json
 from core.memory_types import MemoryRecord, RetrievalQuery, SearchHit
 


### PR DESCRIPTION
## Summary
- Restores `_MissingPackage` sentinel in `core/model_adapter.py`, `core/vector_store.py`, `core/memory_types.py`
- The squash merge of PR #169 accidentally kept the simpler `try/except: np = None` which broke `test_optional_dependency_guards.py`
- This test verifies all 3 modules use `_MissingPackage` so callers get a clear `ImportError` instead of `AttributeError: NoneType`

https://claude.ai/code/session_012Kxs5FZfW3xy9xu1UWuStj