### PR TITLE
security: MCP server hardening — fail-closed auth, zip-slip fix, command lockdown

### DIFF
--- a/tools/mcp_server.py
+++ b/tools/mcp_server.py
@@ -678,14 +678,12 @@ async def call_tool(req: CallRequest, auth: str = Depends(_require_auth)):  # no
     # debug_trace
     # ------------------------------------------------------------------ #
     if name == "debug_trace":
-        # Lightweight, non-executing stub to avoid advertising a tool that always 403s.
-        # This implementation is intentionally limited to echoing back request metadata.
-        return {
-            "data": {
-                "message": "debug_trace is a diagnostic stub and does not execute code.",
-                "received_args": args,
-            }
-        }
+        # Explicitly signal that this tool does not execute code and is not implemented.
+        # Clients should treat this as an unavailable / disabled capability.
+        raise HTTPException(
+            status_code=501,
+            detail="debug_trace is disabled and does not execute modules.",
+        )
 
     raise HTTPException(status_code=404, detail=f"Unknown tool: {name}")
 


### PR DESCRIPTION
## Summary
- Fail-closed auth: server refuses to start without MCP_API_TOKEN
- Timing-safe token comparison via `hmac.compare_digest`
- Rate-limit auth attempts by client IP
- Zip-slip fix: validate extracted paths against destination root
- Remove python/pip/npm/npx from allowed executables
- Add configurable subprocess timeout (`MCP_RUN_TIMEOUT_SECONDS`)
- Sanitize paths in format tool via `_jail()`

Clean replacement for PR #244 — cherry-picked security changes onto current main.

## Test plan
- [ ] Verify server fails to start without MCP_API_TOKEN set
- [ ] Test auth with valid/invalid tokens
- [ ] Test zip extraction with path traversal attempt
- [ ] Verify removed commands (python, pip, npm) are rejected