### PR TITLE
feat: add pre_merge_check.py to catch snapshot drift before merges

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -14,6 +14,9 @@ Recommended update steps:
 - `python3 -m pytest -q tests/test_cli_docs_generator.py tests/test_cli_help_snapshots.py tests/test_cli_error_snapshots.py tests/test_cli_main_dispatch.py -k snapshot`
 - If output changes intentionally, update `tests/snapshots/*` in the same change.
 
+Pre-merge validation (run before opening a PR):
+- `python3 scripts/pre_merge_check.py` — validates CLI reference, help snapshots, and sweep artifact tests are all current. Exits non-zero with coloured ✓/✗ output if any check fails.
+
 ## JSON Output Contracts
 
 ### `cli_errors`

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -57,6 +57,9 @@ def _render_contributor_notes() -> list[str]:
         "- `python3 -m pytest -q tests/test_cli_docs_generator.py tests/test_cli_help_snapshots.py tests/test_cli_error_snapshots.py tests/test_cli_main_dispatch.py -k snapshot`",
         "- If output changes intentionally, update `tests/snapshots/*` in the same change.",
         "",
+        "Pre-merge validation (run before opening a PR):",
+        "- `python3 scripts/pre_merge_check.py` — validates CLI reference, help snapshots, and sweep artifact tests are all current. Exits non-zero with coloured ✓/✗ output if any check fails.",
+        "",
     ]
 
 

--- a/scripts/pre_merge_check.py
+++ b/scripts/pre_merge_check.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Pre-merge snapshot gate.
+
+Runs three CI checks to ensure all auto-generated snapshot files are current
+before a branch is merged into main.  Exits non-zero if any check fails.
+
+Usage::
+
+    python3 scripts/pre_merge_check.py
+
+Environment variables:
+    NO_COLOR   When set to any non-empty value, disables ANSI colour output.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# ANSI colour helpers
+# ---------------------------------------------------------------------------
+
+_NO_COLOR: bool = bool(os.environ.get("NO_COLOR", ""))
+
+_GREEN = "" if _NO_COLOR else "\033[32m"
+_RED = "" if _NO_COLOR else "\033[31m"
+_BOLD = "" if _NO_COLOR else "\033[1m"
+_RESET = "" if _NO_COLOR else "\033[0m"
+
+TICK = f"{_GREEN}✓{_RESET}"
+CROSS = f"{_RED}✗{_RESET}"
+
+# ---------------------------------------------------------------------------
+# Check definitions
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@dataclass
+class Check:
+    """A single gate check."""
+
+    name: str
+    cmd: list[str]
+    description: str
+
+
+CHECKS: list[Check] = [
+    Check(
+        name="CLI reference docs current",
+        cmd=[sys.executable, "scripts/generate_cli_reference.py", "--check"],
+        description="docs/CLI_REFERENCE.md must reflect the current CLI schema",
+    ),
+    Check(
+        name="CLI help snapshots current",
+        cmd=[sys.executable, "-m", "pytest", "tests/test_cli_help_snapshots.py", "-q"],
+        description="Help text snapshot files must match actual CLI output",
+    ),
+    Check(
+        name="Sweep artifact tests pass",
+        cmd=[
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/test_generate_active_sweep_artifacts.py",
+            "-q",
+        ],
+        description="Active-sweep artifact generation tests must pass",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_check(check: Check, *, cwd: Path = REPO_ROOT) -> tuple[bool, str]:
+    """Run *check* and return ``(passed, combined_output)``."""
+    result = subprocess.run(
+        check.cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, combined
+
+
+def main(argv: list[str] | None = None) -> int:  # noqa: ARG001  (reserved for future flags)
+    """Run all checks and return the exit code."""
+    print(f"\n{_BOLD}=== Pre-Merge Snapshot Gate ==={_RESET}\n")
+
+    results: list[tuple[Check, bool, str]] = []
+
+    for check in CHECKS:
+        print(f"  Running: {check.name}…", end=" ", flush=True)
+        passed, output = run_check(check)
+        symbol = TICK if passed else CROSS
+        print(symbol)
+        if not passed and output:
+            # Indent the subprocess output for readability
+            indented = "\n".join(f"    {line}" for line in output.splitlines())
+            print(f"\n{indented}\n")
+        results.append((check, passed, output))
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    passed_count = sum(1 for _, ok, _ in results if ok)
+    total = len(results)
+    all_passed = passed_count == total
+
+    print()
+    print(f"{_BOLD}--- Summary ---{_RESET}")
+    for check, ok, _ in results:
+        symbol = TICK if ok else CROSS
+        print(f"  {symbol}  {check.name}")
+
+    print()
+    summary_color = _GREEN if all_passed else _RED
+    print(
+        f"{_BOLD}{summary_color}{passed_count}/{total} checks passed{_RESET}"
+    )
+
+    if not all_passed:
+        failed_names = [c.name for c, ok, _ in results if not ok]
+        print(
+            f"\n{_RED}Fix the above failures before merging. "
+            f"Failed: {', '.join(failed_names)}{_RESET}"
+        )
+        print(
+            "\nQuick fix hints:"
+            "\n  • Regen CLI reference : python3 scripts/generate_cli_reference.py"
+            "\n  • Update snapshots    : python3 update_snapshots.py"
+            "\n  • Run sweep artifacts : python3 scripts/generate_active_sweep_artifacts.py"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pre_merge_check.py
+++ b/tests/test_pre_merge_check.py
@@ -1,0 +1,206 @@
+"""Tests for scripts/pre_merge_check.py.
+
+Covers:
+  1. All checks pass  → exit code 0
+  2. One check fails  → exit code 1
+  3. All checks fail  → exit code 1
+  4. Output contains each check name in the summary
+  5. NO_COLOR env suppresses ANSI escape sequences
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Load the module under test without executing __main__
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pre_merge_check.py"
+
+
+_MODULE_NAME = "pre_merge_check"
+
+
+def _load_module(env_override: dict[str, str] | None = None) -> types.ModuleType:
+    """Load the script as a module, optionally with patched environment variables.
+
+    The module is registered in *sys.modules* under a unique key each call so
+    that module-level constants (e.g. NO_COLOR) are re-evaluated every time.
+    """
+    # Give each load a unique name so module-level state is not shared between tests.
+    import uuid
+    unique_name = f"{_MODULE_NAME}_{uuid.uuid4().hex}"
+
+    spec = importlib.util.spec_from_file_location(unique_name, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register BEFORE exec so @dataclass can resolve cls.__module__
+    sys.modules[unique_name] = mod
+
+    if env_override is not None:
+        with patch.dict(os.environ, env_override, clear=False):
+            spec.loader.exec_module(mod)
+    else:
+        spec.loader.exec_module(mod)
+
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+def _make_completed_process(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestPreMergeCheckAllPass(unittest.TestCase):
+    """All three subprocess calls succeed → exit code 0."""
+
+    def test_returns_zero_when_all_checks_pass(self) -> None:
+        mod = _load_module()
+        always_ok = _make_completed_process(returncode=0, stdout="ok")
+
+        with patch.object(mod.subprocess, "run", return_value=always_ok):
+            exit_code = mod.main()
+
+        self.assertEqual(exit_code, 0)
+
+    def test_summary_shows_three_of_three(self, capsys=None) -> None:
+        """3/3 checks passed must appear in printed output."""
+        mod = _load_module()
+        always_ok = _make_completed_process(returncode=0)
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with patch.object(mod.subprocess, "run", return_value=always_ok):
+            with redirect_stdout(buf):
+                exit_code = mod.main()
+
+        output = buf.getvalue()
+        self.assertEqual(exit_code, 0)
+        self.assertIn("3/3 checks passed", output)
+
+
+class TestPreMergeCheckOneFailure(unittest.TestCase):
+    """Second check fails → exit code 1."""
+
+    def _side_effect_second_fails(self, *args, **kwargs) -> MagicMock:
+        cmd = args[0] if args else kwargs.get("args", [])
+        # Fail the help-snapshots check (contains 'test_cli_help_snapshots')
+        if any("test_cli_help_snapshots" in str(c) for c in cmd):
+            return _make_completed_process(returncode=1, stdout="FAILED snapshot mismatch")
+        return _make_completed_process(returncode=0, stdout="ok")
+
+    def test_returns_one_when_one_check_fails(self) -> None:
+        mod = _load_module()
+
+        with patch.object(mod.subprocess, "run", side_effect=self._side_effect_second_fails):
+            exit_code = mod.main()
+
+        self.assertEqual(exit_code, 1)
+
+    def test_output_contains_all_check_names(self) -> None:
+        """Every check name must appear in the printed summary regardless of pass/fail."""
+        mod = _load_module()
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with patch.object(mod.subprocess, "run", side_effect=self._side_effect_second_fails):
+            with redirect_stdout(buf):
+                mod.main()
+
+        output = buf.getvalue()
+        for check in mod.CHECKS:
+            self.assertIn(check.name, output, f"Check name '{check.name}' missing from output")
+
+
+class TestPreMergeCheckAllFail(unittest.TestCase):
+    """All checks fail → exit code 1, summary shows 0/3."""
+
+    def test_returns_one_and_zero_of_three(self) -> None:
+        mod = _load_module()
+        always_fail = _make_completed_process(returncode=1, stderr="error")
+
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with patch.object(mod.subprocess, "run", return_value=always_fail):
+            with redirect_stdout(buf):
+                exit_code = mod.main()
+
+        output = buf.getvalue()
+        self.assertEqual(exit_code, 1)
+        self.assertIn("0/3 checks passed", output)
+
+
+class TestPreMergeCheckNoColor(unittest.TestCase):
+    """When NO_COLOR is set the module must not emit ANSI escape codes."""
+
+    def test_no_ansi_when_no_color_set(self) -> None:
+        mod = _load_module(env_override={"NO_COLOR": "1"})
+
+        # The colour constants should be empty strings
+        self.assertEqual(mod._GREEN, "")
+        self.assertEqual(mod._RED, "")
+        self.assertEqual(mod._BOLD, "")
+        self.assertEqual(mod._RESET, "")
+
+
+class TestPreMergeCheckSubprocessCommand(unittest.TestCase):
+    """Verify the exact subprocess commands issued match the spec."""
+
+    def test_three_subprocesses_called(self) -> None:
+        mod = _load_module()
+        always_ok = _make_completed_process(returncode=0)
+        call_log: list = []
+
+        def recording_run(*args, **kwargs):
+            call_log.append(args[0] if args else kwargs.get("args"))
+            return always_ok
+
+        with patch.object(mod.subprocess, "run", side_effect=recording_run):
+            mod.main()
+
+        self.assertEqual(len(call_log), 3, "Expected exactly 3 subprocess calls")
+
+    def test_cli_reference_check_flag_present(self) -> None:
+        """The generate_cli_reference invocation must include --check."""
+        mod = _load_module()
+        always_ok = _make_completed_process(returncode=0)
+        call_log: list = []
+
+        def recording_run(*args, **kwargs):
+            call_log.append(args[0] if args else kwargs.get("args"))
+            return always_ok
+
+        with patch.object(mod.subprocess, "run", side_effect=recording_run):
+            mod.main()
+
+        ref_cmd = call_log[0]
+        self.assertIn("--check", ref_cmd)
+        self.assertIn("generate_cli_reference.py", str(ref_cmd))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `scripts/pre_merge_check.py` — a CI gate that validates all auto-generated snapshot files are current before a branch is merged.

## Problem
CI has repeatedly failed because developers forget to regenerate snapshots after CLI changes. This gate makes the failure visible at dev time, not after pushing.

## Changes

### `scripts/pre_merge_check.py` (new)
Runs three checks in sequence:
1. `python3 scripts/generate_cli_reference.py --check` — docs/CLI_REFERENCE.md current?
2. `python3 -m pytest tests/test_cli_help_snapshots.py -q` — help snapshots current?
3. `python3 -m pytest tests/test_generate_active_sweep_artifacts.py -q` — sweep artifact tests pass?

Prints coloured **✓/✗** per check, then a final **N/3 checks passed** summary. Exits 1 if any check fails. Respects `NO_COLOR` env var.

### `tests/test_pre_merge_check.py` (new)
8 unit tests using `unittest.mock`:
- All-pass returns exit code 0
- One-fail returns exit code 1 and shows the failing check name
- All-fail shows 0/3 in summary
- All check names appear in output
- `NO_COLOR` suppresses ANSI escape codes
- Exactly 3 subprocesses are called
- `--check` flag is present in the CLI reference invocation

### `scripts/generate_cli_reference.py`
Adds pre-merge validation note to `_render_contributor_notes()` so it appears in the auto-generated CLI reference.

### `docs/CLI_REFERENCE.md`
Regenerated to include the pre-merge validation hint.

## Testing
```
python3 -m pytest tests/test_pre_merge_check.py -v   # 8/8 passed
python3 scripts/pre_merge_check.py                    # 3/3 checks passed, exit 0
```