### PR TITLE
security: fix env_snapshot disclosure + prompt injection

### DIFF
--- a/core/model_adapter.py
+++ b/core/model_adapter.py
@@ -321,12 +321,13 @@ class ModelAdapter:
         else:
             raise ValueError("Local command profile requires `command` as a string or string list.")
 
+        sanitized_prompt = shlex.quote(prompt) if prompt else ""
         use_stdin = True
         rendered_parts: list[str] = []
         for part in command_parts:
             if "{prompt}" in part:
                 use_stdin = False
-                rendered_parts.append(part.replace("{prompt}", prompt))
+                rendered_parts.append(part.replace("{prompt}", sanitized_prompt))
             else:
                 rendered_parts.append(part)
 

--- a/tests/test_mcp_env_whitelist.py
+++ b/tests/test_mcp_env_whitelist.py
@@ -1,0 +1,104 @@
+"""Tests for MCP env_snapshot whitelist security fix (issue #332)."""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+
+class TestEnvSnapshotWhitelist:
+    """env_snapshot must not leak arbitrary environment variables."""
+
+    def test_whitelist_constant_exists(self):
+        """ENV_WHITELIST must be defined at module level in mcp_server."""
+        import tools.mcp_server as mcp_server
+
+        assert hasattr(mcp_server, "ENV_WHITELIST"), (
+            "tools/mcp_server.py must define ENV_WHITELIST at module level"
+        )
+        whitelist = mcp_server.ENV_WHITELIST
+        assert isinstance(whitelist, (set, frozenset))
+        for key in ("PYTHONPATH", "PATH", "HOME", "USER",
+                    "AURA_SKIP_CHDIR", "AURA_ENABLE_SWARM"):
+            assert key in whitelist, f"ENV_WHITELIST must contain {key!r}"
+
+    def test_helper_exists(self):
+        """_env_snapshot helper must be importable from tools.mcp_server."""
+        import tools.mcp_server as mcp_server
+
+        assert hasattr(mcp_server, "_env_snapshot"), (
+            "tools/mcp_server.py must define a _env_snapshot(args) helper"
+        )
+
+    def test_no_keys_returns_only_whitelisted_vars(self):
+        """Without explicit keys, only whitelisted env vars are returned."""
+        import tools.mcp_server as mcp_server
+
+        fake_env = {
+            "PATH": "/usr/bin",
+            "HOME": "/home/user",
+            "USER": "testuser",
+            "PYTHONPATH": "",
+            "AURA_SKIP_CHDIR": "1",
+            "AURA_ENABLE_SWARM": "0",
+            "SECRET_API_KEY": "super-secret-value",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "OPENAI_API_KEY": "openai-key",
+        }
+
+        with patch.dict(os.environ, fake_env, clear=True):
+            result = mcp_server._env_snapshot({})
+
+        snapshot = result["data"]["env"]
+        assert "SECRET_API_KEY" not in snapshot, "SECRET_API_KEY must not be in snapshot"
+        assert "AWS_SECRET_ACCESS_KEY" not in snapshot
+        assert "OPENAI_API_KEY" not in snapshot
+        assert snapshot.get("PATH") == "/usr/bin"
+        assert snapshot.get("HOME") == "/home/user"
+        assert snapshot.get("USER") == "testuser"
+
+    def test_explicit_keys_still_allowed(self):
+        """Explicit key request (caller-specified) should still be honored."""
+        import tools.mcp_server as mcp_server
+
+        fake_env = {
+            "PATH": "/usr/bin",
+            "MY_CUSTOM_VAR": "hello",
+        }
+        with patch.dict(os.environ, fake_env, clear=True):
+            result = mcp_server._env_snapshot({"keys": ["PATH", "MY_CUSTOM_VAR"]})
+
+        snapshot = result["data"]["env"]
+        assert snapshot.get("PATH") == "/usr/bin"
+        assert snapshot.get("MY_CUSTOM_VAR") == "hello"
+
+    def test_whitelist_excludes_secrets_even_if_set(self):
+        """Non-whitelisted vars are always excluded when no explicit keys given."""
+        import tools.mcp_server as mcp_server
+
+        malicious_env = {k: "value" for k in (
+            "GEMINI_API_KEY", "ANTHROPIC_API_KEY", "GITHUB_TOKEN",
+            "DATABASE_URL", "REDIS_PASSWORD"
+        )}
+        malicious_env["PATH"] = "/usr/bin"
+
+        with patch.dict(os.environ, malicious_env, clear=True):
+            result = mcp_server._env_snapshot({})
+
+        snapshot = result["data"]["env"]
+        for key in malicious_env:
+            if key != "PATH":
+                assert key not in snapshot, f"{key} must not appear in snapshot"
+        assert "PATH" in snapshot
+
+    def test_missing_whitelisted_key_returns_empty_string(self):
+        """Whitelisted vars absent from the real env return empty string."""
+        import tools.mcp_server as mcp_server
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = mcp_server._env_snapshot({})
+
+        snapshot = result["data"]["env"]
+        # All whitelisted keys must be present; absent ones map to ""
+        for key in mcp_server.ENV_WHITELIST:
+            assert key in snapshot
+            assert snapshot[key] == ""

--- a/tests/test_model_adapter_security.py
+++ b/tests/test_model_adapter_security.py
@@ -1,0 +1,152 @@
+"""Tests for subprocess prompt injection sanitization (issue #333)."""
+from __future__ import annotations
+
+import shlex
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestLocalCommandProfileSanitization:
+    """_call_local_command_profile must sanitize shell metacharacters in prompt."""
+
+    def _make_adapter(self):
+        from core.model_adapter import ModelAdapter
+        return ModelAdapter.__new__(ModelAdapter)
+
+    def test_shell_metacharacters_are_escaped_in_rendered_parts(self):
+        """Shell metacharacters in prompt must not appear unquoted in rendered args."""
+        adapter = self._make_adapter()
+        profile = {"command": "echo {prompt}"}
+        malicious_prompt = "hello; rm -rf / && echo pwned"
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            m = MagicMock()
+            m.stdout = "safe"
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            adapter._call_local_command_profile(profile, malicious_prompt)
+
+        rendered_prompt_arg = captured["args"][1]  # echo <prompt>
+        # The semicolon and ampersands must be quoted/escaped — they should not
+        # appear as bare tokens that the shell could interpret.
+        assert ";" not in rendered_prompt_arg or rendered_prompt_arg.startswith("'") or \
+               rendered_prompt_arg.startswith('"'), (
+            f"Prompt metacharacters not sanitized. Got: {rendered_prompt_arg!r}"
+        )
+        # shlex.quote wraps in single quotes; the raw semicolon should be inside quotes
+        expected = shlex.quote(malicious_prompt)
+        assert rendered_prompt_arg == expected, (
+            f"Expected shlex.quote result {expected!r}, got {rendered_prompt_arg!r}"
+        )
+
+    def test_backtick_injection_escaped(self):
+        """Backtick command substitution must be neutralized."""
+        adapter = self._make_adapter()
+        profile = {"command": "mymodel {prompt}"}
+        prompt_with_backtick = "`cat /etc/passwd`"
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            m = MagicMock()
+            m.stdout = "safe"
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            adapter._call_local_command_profile(profile, prompt_with_backtick)
+
+        rendered = captured["args"][1]
+        expected = shlex.quote(prompt_with_backtick)
+        assert rendered == expected
+
+    def test_dollar_substitution_escaped(self):
+        """Dollar-sign variable substitution must be neutralized."""
+        adapter = self._make_adapter()
+        profile = {"command": "mymodel {prompt}"}
+        prompt = "$(whoami) said hello"
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            m = MagicMock()
+            m.stdout = "safe"
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            adapter._call_local_command_profile(profile, prompt)
+
+        rendered = captured["args"][1]
+        expected = shlex.quote(prompt)
+        assert rendered == expected
+
+    def test_safe_prompt_passes_through_quoted(self):
+        """A normal prompt should still work — just be shlex-quoted."""
+        adapter = self._make_adapter()
+        profile = {"command": "echo {prompt}"}
+        safe_prompt = "What is the capital of France?"
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            m = MagicMock()
+            m.stdout = "Paris"
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = adapter._call_local_command_profile(profile, safe_prompt)
+
+        rendered = captured["args"][1]
+        # shlex.quote of a safe string wraps it in single quotes
+        assert rendered == shlex.quote(safe_prompt)
+        assert result == "Paris"
+
+    def test_empty_prompt_handled(self):
+        """Empty/None prompt must not raise and must produce an empty string."""
+        adapter = self._make_adapter()
+        profile = {"command": "echo {prompt}"}
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            m = MagicMock()
+            m.stdout = ""
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            adapter._call_local_command_profile(profile, "")
+
+        rendered = captured["args"][1]
+        # shlex.quote("") returns "''" — that is acceptable
+        assert rendered == shlex.quote("") or rendered == ""
+
+    def test_stdin_path_not_affected(self):
+        """When prompt goes via stdin (no {prompt} in command), args are untouched."""
+        adapter = self._make_adapter()
+        profile = {"command": "mymodel --stdin"}
+        malicious_prompt = "hello; rm -rf /"
+
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            captured["input"] = kwargs.get("input")
+            m = MagicMock()
+            m.stdout = "ok"
+            return m
+
+        with patch("subprocess.run", side_effect=fake_run):
+            adapter._call_local_command_profile(profile, malicious_prompt)
+
+        # stdin path: prompt goes to input=, not into args
+        assert captured["args"] == ["mymodel", "--stdin"]
+        assert captured["input"] == malicious_prompt

--- a/tools/mcp_server.py
+++ b/tools/mcp_server.py
@@ -62,6 +62,34 @@ RUN_TIMEOUT_SECONDS: int = int(os.getenv("MCP_RUN_TIMEOUT_SECONDS", "30"))
 #: Rate-limit ceiling (calls per minute, per token).  0 = disabled.
 RATE_LIMIT_PER_MIN: int = int(os.getenv("MCP_RATE_LIMIT_PER_MIN", "0"))
 
+#: Allowed environment variable names returned by ``env_snapshot`` when no
+#: explicit key list is provided.  Prevents disclosure of secrets/tokens.
+ENV_WHITELIST: frozenset = frozenset({
+    "PYTHONPATH",
+    "PATH",
+    "HOME",
+    "USER",
+    "AURA_SKIP_CHDIR",
+    "AURA_ENABLE_SWARM",
+})
+
+
+def _env_snapshot(args: dict) -> dict:
+    """Return a safe environment snapshot.
+
+    When *args* contains a ``keys`` list the caller-specified keys are
+    returned verbatim (existing behaviour for explicit requests).  When no
+    keys are requested only whitelisted variables are included so that API
+    keys, tokens, and other secrets are never inadvertently disclosed.
+    """
+    keys = args.get("keys", None)
+    if keys:
+        snapshot = {k: os.environ.get(k, "") for k in keys}
+    else:
+        snapshot = {k: os.environ.get(k, "") for k in ENV_WHITELIST}
+    return {"data": {"env": snapshot}}
+
+
 # ---------------------------------------------------------------------------
 # Rate-limit state (in-process, per-token sliding window)
 # ---------------------------------------------------------------------------
@@ -595,9 +623,7 @@ async def call_tool(req: CallRequest, auth: str = Depends(_require_auth)):  # no
     # env_snapshot
     # ------------------------------------------------------------------ #
     if name == "env_snapshot":
-        keys = args.get("keys", None)
-        snapshot = {k: os.environ.get(k, "") for k in keys} if keys else dict(os.environ)
-        return {"data": {"env": snapshot}}
+        return _env_snapshot(args)
 
     # ------------------------------------------------------------------ #
     # package_scripts


### PR DESCRIPTION
## Summary
- MCP env_snapshot now returns only whitelisted env vars by default
- model_adapter sanitizes prompts with shlex.quote() before subprocess args

Closes #332, #333

## Test plan
- [ ] 12 new security tests pass
- [ ] No regressions