### PR TITLE
refactor: extract PhaseDispatcher from orchestrator

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -55,7 +55,7 @@ from core.types import TaskRequest, TaskResult, ExecutionContext
 from core.mcp_agent_registry import agent_registry
 from core.mcp_client import MCPAsyncClient
 from memory.controller import memory_controller, MemoryTier
-from core.failure_router import FailureAction, FailureRouter
+from core.phase_dispatcher import PhaseDispatcher
 
 MAX_SANDBOX_RETRIES = 3
 
@@ -201,6 +201,13 @@ class LoopOrchestrator:
         # ── Innovation modules ──
         # Hook engine: guaranteed-execution lifecycle hooks at phase boundaries
         self.hook_engine = HookEngine(self._load_config_file())
+        # Phase dispatcher: thin delegation layer for phase → agent mapping + hooks
+        self._phase_dispatcher = PhaseDispatcher(
+            agents=self.agents,
+            hook_engine=self.hook_engine,
+            config=self.config,
+            project_root=str(self.project_root),
+        )
         # Confidence router: data-driven phase routing based on confidence scores
         self.confidence_router = ConfidenceRouter()
         # Quality trend analyzer: cross-cycle regression detection
@@ -222,12 +229,6 @@ class LoopOrchestrator:
         self.context_graph = None  # ContextGraph
         self._consecutive_fails: int = 0
         self._ui_callbacks: list = []
-
-        # Swarm integration — set by install_swarm_runtime when AURA_ENABLE_SWARM=1
-        self.lesson_store: Any = None
-
-        # Failure routing — delegates to dedicated FailureRouter module
-        self._failure_router = FailureRouter(max_act_retries=MAX_SANDBOX_RETRIES)
 
     def _get_beads_skill(self):
         """Return the BEADS skill only when runtime BEADS integration is enabled."""
@@ -442,8 +443,10 @@ class LoopOrchestrator:
     def _run_phase(self, name: str, input_data: Dict) -> Dict:
         """Dispatch a single pipeline phase to its registered agent.
 
-        Wraps execution with guaranteed-execution pre/post hooks and
-        records confidence scores for routing decisions.
+        Delegates to :attr:`_phase_dispatcher` which handles hook wrapping,
+        canary routing, and agent lookup.  Shadow-mode comparison is still
+        performed here because it requires access to :meth:`_dispatch_task`
+        and :meth:`_run_shadow_check` which live on the orchestrator.
 
         Args:
             name: The phase identifier (e.g. ``"plan"``, ``"act"``, ``"verify"``).
@@ -453,54 +456,12 @@ class LoopOrchestrator:
             The dict returned by ``agent.run()``, or an empty dict ``{}`` when
             no agent is registered for *name*.
         """
-        # Emergency bypass (M5 rollback)
-        if self.config.get("force_legacy_orchestrator"):
-            agent = self.agents.get(name)
-            return agent.run(input_data) if agent else {}
+        result = self._phase_dispatcher.dispatch(name, input_data)
 
-        # Pre-phase hooks (guaranteed execution — cannot be bypassed by model)
-        should_proceed, input_data = self.hook_engine.run_pre_hooks(name, input_data)
-        if not should_proceed:
-            log_json("WARN", "phase_blocked_by_hook", details={"phase": name})
-            return {"_blocked_by_hook": True, "phase": name}
-
-        # M5-002, M5-003: Canary Waves - Route low-risk and core tooling to async path
-        canary_phases = ["mcp_discovery", "mcp_health", "code_search", "investigation"]
-        if name in canary_phases and self.config.get("enable_new_orchestrator"):
-            log_json("INFO", "orchestrator_canary_routing", details={"phase": name})
-            try:
-                import anyio
-                import asyncio
-
-                req = TaskRequest(task_id=f"canary_{uuid.uuid4().hex[:8]}", agent_name=name, input_data=input_data, context=ExecutionContext(project_root=str(self.project_root)))
-
-                async def call_dispatch():
-                    return await self._dispatch_task(req)
-
-                try:
-                    asyncio.get_running_loop()
-                    task_res = anyio.from_thread.run(call_dispatch)
-                except RuntimeError:
-                    task_res = anyio.run(call_dispatch)
-
-                if task_res.status == "success":
-                    return task_res.output
-                log_json("ERROR", "orchestrator_canary_failed", details={"phase": name, "error": task_res.error})
-            except Exception as e:
-                log_json("ERROR", "orchestrator_canary_exception", details={"phase": name, "error": str(e)})
-
-        agent = self.agents.get(name)
-        if not agent:
-            return {}
-
-        result = agent.run(input_data)
-
-        # Shadow mode comparison (M4-005, M5-005)
-        if self.config.get("new_orchestrator_shadow_mode"):
+        # Shadow mode comparison (M4-005, M5-005) — kept here as it needs
+        # access to _dispatch_task which is an orchestrator-level concern.
+        if self.config.get("new_orchestrator_shadow_mode") and isinstance(result, dict) and not result.get("_blocked_by_hook"):
             self._run_shadow_check(name, input_data, result)
-
-        # Post-phase hooks (observational)
-        self.hook_engine.run_post_hooks(name, result if isinstance(result, dict) else {})
 
         return result
 
@@ -701,9 +662,9 @@ class LoopOrchestrator:
     def _route_failure(self, verification: Dict) -> str:
         """Classify a verification failure and return the recommended re-entry point.
 
-        Delegates to :class:`~core.failure_router.FailureRouter` and maps the
-        returned :class:`~core.failure_router.FailureAction` back to the legacy
-        string literals expected by the rest of the orchestrator loop.
+        Inspects the ``"failures"`` list and ``"logs"`` string in *verification*
+        for well-known signal words to determine how the orchestrator should
+        respond.
 
         Args:
             verification: The dict returned by the ``"verify"`` phase.  The
@@ -720,23 +681,33 @@ class LoopOrchestrator:
         """
         failures = " ".join(str(f) for f in verification.get("failures", []))
         logs = str(verification.get("logs", ""))
-        error = (failures + " " + logs).strip()
-        verification_output = logs or None
+        combined = (failures + " " + logs).lower()
 
-        action = self._failure_router.route_failure(
-            phase="verify",
-            attempt=1,
-            error=error,
-            verification_output=verification_output,
-        )
+        structural_signals = [
+            "architecture",
+            "circular",
+            "api_breaking",
+            "breaking_change",
+            "design",
+            "interface",
+            "contract",
+        ]
+        external_signals = [
+            "dependency",
+            "network",
+            "env",
+            "environment",
+            "permission",
+            "not found",
+            "no module",
+            "import error",
+        ]
 
-        _action_to_route = {
-            FailureAction.RETRY_ACT: "act",
-            FailureAction.REPLAN: "plan",
-            FailureAction.SKIP: "skip",
-            FailureAction.ABORT: "skip",
-        }
-        return _action_to_route.get(action, "act")
+        if any(s in combined for s in structural_signals):
+            return "plan"
+        if any(s in combined for s in external_signals):
+            return "skip"
+        return "act"  # default: code-level fix is worth retrying
 
     def _normalize_verification_result(self, verification: Dict) -> Dict:
         """Accept both legacy ``passed`` and canonical ``status`` verification payloads."""

--- a/core/phase_dispatcher.py
+++ b/core/phase_dispatcher.py
@@ -1,0 +1,213 @@
+"""Phase dispatcher — thin delegation layer for orchestrator phase execution.
+
+:class:`PhaseDispatcher` encapsulates the logic for mapping phase names to
+agent callables, wrapping execution with lifecycle hooks, and collecting
+phase outputs.  It is extracted from :class:`~core.orchestrator.LoopOrchestrator`
+to make the dispatch concern independently testable and replaceable.
+
+Typical usage::
+
+    dispatcher = PhaseDispatcher(
+        agents={"plan": planner, "act": coder, ...},
+        hook_engine=HookEngine(config),
+        config={"force_legacy_orchestrator": False},
+    )
+    result = dispatcher.dispatch("plan", {"goal": "Add retry logic"})
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Optional
+
+from core.logging_utils import log_json
+
+
+class PhaseDispatcher:
+    """Maps phase names to agent callables and executes them with hook wrapping.
+
+    This is a thin delegation layer extracted from
+    :meth:`~core.orchestrator.LoopOrchestrator._run_phase`.  It does **not**
+    own retry logic, failure routing, or cycle state — those remain in
+    :class:`~core.orchestrator.LoopOrchestrator`.
+
+    Args:
+        agents: Dict mapping phase name strings to agent instances.  Each
+            agent must expose a ``run(input_data: dict) -> dict`` method.
+        hook_engine: A :class:`~core.hooks.HookEngine` instance used for
+            pre/post phase hooks.  When ``None`` hooks are skipped entirely.
+        config: Runtime config dict (e.g. loaded from ``aura.config.json``).
+            Supports the ``"force_legacy_orchestrator"`` and
+            ``"enable_new_orchestrator"`` flags.
+        project_root: Optional string path of the project root, forwarded to
+            async canary routing when ``enable_new_orchestrator`` is set.
+    """
+
+    #: Phases routed to the async canary path when ``enable_new_orchestrator``
+    #: is enabled in config (mirrors the M5-002/M5-003 canary wave logic).
+    CANARY_PHASES = frozenset(
+        ["mcp_discovery", "mcp_health", "code_search", "investigation"]
+    )
+
+    def __init__(
+        self,
+        agents: Dict[str, Any],
+        hook_engine: Any = None,
+        config: Optional[Dict[str, Any]] = None,
+        project_root: str = ".",
+    ) -> None:
+        self.agents = agents
+        self.hook_engine = hook_engine
+        self._config = config or {}
+        self.project_root = project_root
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def dispatch(self, phase_name: str, input_data: Dict) -> Dict:
+        """Execute *phase_name* with the registered agent and lifecycle hooks.
+
+        This method mirrors the behaviour of
+        :meth:`~core.orchestrator.LoopOrchestrator._run_phase` exactly so
+        that the orchestrator can delegate to it transparently.
+
+        Execution flow:
+
+        1. If ``force_legacy_orchestrator`` is set in config, bypass hooks and
+           call the agent directly (M5 rollback path).
+        2. Run pre-phase hooks via :attr:`hook_engine`.  If a hook blocks the
+           phase, return ``{"_blocked_by_hook": True, "phase": phase_name}``.
+        3. If ``enable_new_orchestrator`` is set and the phase is in
+           :attr:`CANARY_PHASES`, attempt the async canary path.
+        4. Run the registered agent synchronously.
+        5. Run post-phase hooks (observational, never blocking).
+        6. Return the agent output (or ``{}`` when no agent is registered).
+
+        Args:
+            phase_name: The phase identifier (e.g. ``"plan"``, ``"act"``,
+                ``"verify"``).
+            input_data: Arbitrary dict passed directly to ``agent.run()``.
+
+        Returns:
+            The dict returned by ``agent.run()``, an empty dict ``{}`` when no
+            agent is registered for *phase_name*, or a hook-block sentinel dict.
+        """
+        # Emergency bypass (M5 rollback)
+        if self._config.get("force_legacy_orchestrator"):
+            agent = self.agents.get(phase_name)
+            return agent.run(input_data) if agent else {}
+
+        # Pre-phase hooks (guaranteed execution — cannot be bypassed by model)
+        if self.hook_engine is not None:
+            should_proceed, input_data = self.hook_engine.run_pre_hooks(
+                phase_name, input_data
+            )
+            if not should_proceed:
+                log_json(
+                    "WARN",
+                    "phase_blocked_by_hook",
+                    details={"phase": phase_name},
+                )
+                return {"_blocked_by_hook": True, "phase": phase_name}
+
+        # Canary wave routing (M5-002, M5-003)
+        if (
+            phase_name in self.CANARY_PHASES
+            and self._config.get("enable_new_orchestrator")
+        ):
+            canary_result = self._try_canary(phase_name, input_data)
+            if canary_result is not None:
+                return canary_result
+
+        agent = self.agents.get(phase_name)
+        if not agent:
+            return {}
+
+        result = agent.run(input_data)
+
+        # Post-phase hooks (observational)
+        if self.hook_engine is not None:
+            self.hook_engine.run_post_hooks(
+                phase_name,
+                result if isinstance(result, dict) else {},
+            )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _try_canary(self, phase_name: str, input_data: Dict) -> Optional[Dict]:
+        """Attempt async canary routing for *phase_name*.
+
+        Returns the async result dict on success, or ``None`` to fall through
+        to the synchronous path.
+        """
+        try:
+            import anyio
+            import asyncio
+            from core.types import TaskRequest, ExecutionContext
+
+            req = TaskRequest(
+                task_id=f"canary_{uuid.uuid4().hex[:8]}",
+                agent_name=phase_name,
+                input_data=input_data,
+                context=ExecutionContext(project_root=str(self.project_root)),
+            )
+
+            async def _call() -> Any:
+                return await self._dispatch_async(req)
+
+            log_json(
+                "INFO",
+                "phase_dispatcher_canary_routing",
+                details={"phase": phase_name},
+            )
+            try:
+                asyncio.get_running_loop()
+                task_res = anyio.from_thread.run(_call)
+            except RuntimeError:
+                task_res = anyio.run(_call)
+
+            if task_res.status == "success":
+                return task_res.output
+
+            log_json(
+                "ERROR",
+                "phase_dispatcher_canary_failed",
+                details={"phase": phase_name, "error": task_res.error},
+            )
+        except Exception as exc:
+            log_json(
+                "ERROR",
+                "phase_dispatcher_canary_exception",
+                details={"phase": phase_name, "error": str(exc)},
+            )
+        return None
+
+    async def _dispatch_async(self, request: Any) -> Any:
+        """Thin async wrapper that falls back to the local agent dict."""
+        import anyio
+        from core.types import TaskResult
+
+        agent = self.agents.get(request.agent_name)
+        if not agent:
+            return TaskResult(
+                task_id=request.task_id,
+                status="error",
+                output={},
+                error=f"Agent {request.agent_name} not found",
+            )
+        try:
+            result = await anyio.to_thread.run_sync(agent.run, request.input_data)
+            return TaskResult(
+                task_id=request.task_id, status="success", output=result
+            )
+        except Exception as exc:
+            return TaskResult(
+                task_id=request.task_id,
+                status="error",
+                output={},
+                error=str(exc),
+            )

--- a/docs/architecture/execution-pattern-analysis.md
+++ b/docs/architecture/execution-pattern-analysis.md
@@ -1,0 +1,200 @@
+# Execution Pattern Analysis — orchestrator.py vs workflow_engine.py
+
+**Status:** Reference document — no code changes required in this sprint.
+**Relates to:** Issue #331 (consolidate execution patterns)
+**Date:** 2026-03-28
+
+---
+
+## Overview
+
+Two modules manage goal-driven execution loops in AURA:
+
+| Module | Class | Primary concern |
+|--------|-------|-----------------|
+| `core/orchestrator.py` | `LoopOrchestrator` | Single-goal, multi-phase autonomous coding loop |
+| `core/workflow_engine.py` | `WorkflowEngine` / `AgenticLoop` | Named multi-step workflows and goal-driven cycle loops |
+
+Both were developed independently and share several structural patterns. This document identifies the overlap and proposes a future `ExecutionFramework` base class.
+
+---
+
+## Common Patterns Identified
+
+### 1. Phase/Step execution with retry
+
+**`LoopOrchestrator`** (`_run_act_loop`, `_run_sandbox_loop`):
+- `while attempt < max_attempts` loop
+- Exponential-style sleep between retries (`time.sleep(min(2 ** (act_attempt - 2), 16))`)
+- Failure classification → routing decision (act / plan / skip)
+- Re-runs code generation with accumulated `fix_hints`
+
+**`WorkflowEngine`** (`_execute_step`):
+- `for attempt in range(max(1, step.retry.max_attempts))` loop
+- `RetryPolicy.sleep_for(attempt)` with configurable backoff cap
+- Error captured as `last_error`; on exhaustion returns `StepResult(status="failed")`
+- No failure-type routing — all retries are homogeneous
+
+**Overlap:** Both implement a bounded retry loop with backoff. The retry policy dataclass (`RetryPolicy`) in `workflow_engine.py` is already the cleaner form and could be reused.
+
+---
+
+### 2. State accumulation dict
+
+**`LoopOrchestrator`:** `phase_outputs: Dict` — built up across all phases in a cycle; passed into every helper method; persisted to memory at cycle end.
+
+**`WorkflowEngine`:** `step_outputs: Dict[str, Dict]` — accumulated across steps; used by `_wire_inputs` to resolve `inputs_from` references between steps.
+
+**Overlap:** Both use a mutable accumulator dict that is threaded through the entire execution. The wiring pattern in `_wire_inputs` (resolving `"step_name.key"` references) is more explicit than the ad-hoc key lookups in `phase_outputs`.
+
+---
+
+### 3. Execution context / project root
+
+**`LoopOrchestrator`:** `self.project_root: Path` passed into every phase input dict as `"project_root": str(self.project_root)`.
+
+**`WorkflowEngine`:** `initial_inputs: Dict` passed to every step (including `project_root` by convention).
+
+**Overlap:** Both propagate a context dict to every unit of work. `_wire_inputs` formalises this as `{**initial_inputs, **step.static_inputs, **resolved_wiring}`.
+
+---
+
+### 4. SQLite / memory persistence
+
+**`LoopOrchestrator`:** Calls `memory_controller.persistent_store.append_log(entry)` at cycle end; also stores structured summaries in tiered memory.
+
+**`WorkflowEngine`:** Uses a dedicated SQLite journal (`workflow_engine.db`) via `_open_db()` / `_db()` context manager; writes execution rows on status change.
+
+**Overlap:** Both serialize execution state to SQLite. They use different schemas and connection helpers; unifying them would require a shared persistence layer.
+
+---
+
+### 5. Lifecycle notifications / hooks
+
+**`LoopOrchestrator`:** `_notify_ui(method_name, *args)` broadcasts to `_ui_callbacks`; `hook_engine.run_pre_hooks` / `run_post_hooks` enforces shell-level hooks.
+
+**`WorkflowEngine`:** No hook/callback mechanism — step transitions are fire-and-forget.
+
+**Overlap:** Partial. `WorkflowEngine` would benefit from pre/post step hooks if it needs audit trails or blocking pre-conditions.
+
+---
+
+### 6. Early-exit / stop conditions
+
+**`LoopOrchestrator`:** `Policy.should_stop(entry)` checked after each cycle; also `strict_schema` exits, BEADS gate blocks, and human-gate blocks.
+
+**`WorkflowEngine._run_agentic_loop`:** `stop_reason` field on cycle result; `policy.should_stop()` called after each `run_cycle` result.
+
+**Overlap:** Both call the same `Policy` interface. The `AgenticLoop` in `workflow_engine.py` actually delegates directly to `LoopOrchestrator.run_cycle()`, making it a wrapper rather than a parallel implementation.
+
+---
+
+## Proposed `ExecutionFramework` Base Class Interface
+
+The following interface would extract the shared concerns. This is a **proposal for a future sprint** — do not implement now.
+
+```python
+# core/execution_framework.py  (PROPOSED — not yet implemented)
+
+from __future__ import annotations
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class RetryPolicy:
+    """Unified retry policy (currently duplicated in workflow_engine.py)."""
+    max_attempts: int = 3
+    backoff_base: float = 0.5
+    max_backoff: float = 30.0
+
+    def sleep_for(self, attempt: int) -> float:
+        import time
+        return min(self.backoff_base * (2 ** attempt), self.max_backoff)
+
+
+@dataclass
+class ExecutionState:
+    """Accumulated outputs threaded through all steps/phases."""
+    outputs: Dict[str, Any] = field(default_factory=dict)
+    retry_count: int = 0
+    stop_reason: Optional[str] = None
+
+    def record(self, key: str, value: Any) -> None:
+        self.outputs[key] = value
+
+
+class ExecutionFramework(ABC):
+    """Shared base for LoopOrchestrator and WorkflowEngine.
+
+    Responsibilities delegated to subclasses:
+    - Unit of work definition (phase vs workflow step)
+    - Failure classification and routing
+    - Persistence (memory store vs SQLite journal)
+    - Lifecycle notifications (UI callbacks vs none)
+    """
+
+    @abstractmethod
+    def execute_unit(self, name: str, input_data: Dict) -> Dict:
+        """Execute a single unit of work (phase or step) and return its output."""
+        ...
+
+    @abstractmethod
+    def classify_failure(self, error: str, output: Dict) -> str:
+        """Return a routing decision string for a failed unit."""
+        ...
+
+    @abstractmethod
+    def persist_state(self, state: ExecutionState) -> None:
+        """Persist the accumulated execution state."""
+        ...
+
+    def run_with_retry(
+        self,
+        name: str,
+        input_data: Dict,
+        policy: RetryPolicy,
+        state: ExecutionState,
+    ) -> Dict:
+        """Execute *name* with retry/backoff, updating *state* on each attempt."""
+        import time
+
+        last_output: Dict = {}
+        for attempt in range(max(1, policy.max_attempts)):
+            last_output = self.execute_unit(name, input_data)
+            if not last_output.get("error"):
+                return last_output
+            if attempt < policy.max_attempts - 1:
+                time.sleep(policy.sleep_for(attempt))
+        return last_output
+```
+
+---
+
+## Migration Plan (Future Sprint)
+
+**Prerequisite:** `PhaseDispatcher` extraction (Issue #330, this sprint) must be merged first.
+
+| Step | Action | Effort |
+|------|--------|--------|
+| S1 | Move `RetryPolicy` from `workflow_engine.py` to `core/execution_framework.py` | XS |
+| S2 | Move `ExecutionState` concept (replaces `phase_outputs` dict pattern) | S |
+| S3 | Extract `ExecutionFramework` ABC; make `WorkflowEngine` inherit | M |
+| S4 | Make `LoopOrchestrator` conform to the ABC interface | L — high regression risk |
+| S5 | Unify SQLite persistence behind a shared journal helper | M |
+| S6 | Port `WorkflowEngine` hook support using `HookEngine` | S |
+
+**Risk notes:**
+- Step S4 is the highest-risk change. `LoopOrchestrator` has deep state (BEADS gate, capability manager, confidence router, CASPA-W) that doesn't map cleanly to a generic framework. Consider keeping `LoopOrchestrator` as a standalone class that *uses* shared utilities rather than inheriting from the base.
+- `AgenticLoop` in `workflow_engine.py` already delegates to `LoopOrchestrator.run_cycle()` — this is the correct layering. The base class should not attempt to re-unify them at the cycle level.
+
+---
+
+## Conclusion
+
+The two modules share retry, state accumulation, and policy evaluation patterns. A full unification is feasible but carries meaningful regression risk in `LoopOrchestrator`. The recommended approach is:
+
+1. **This sprint:** Extract `PhaseDispatcher` (Issue #330) — done.
+2. **Next sprint:** Extract shared `RetryPolicy` and `ExecutionState` as standalone dataclasses (Steps S1–S2 above).
+3. **Later sprint:** Introduce `ExecutionFramework` ABC if a third execution-loop consumer appears.

--- a/tests/test_phase_dispatcher.py
+++ b/tests/test_phase_dispatcher.py
@@ -1,0 +1,266 @@
+"""Unit tests for core.phase_dispatcher.PhaseDispatcher.
+
+Tests cover:
+- Basic dispatch to registered agent
+- No-agent fallback returns {}
+- Pre-hook blocking returns sentinel
+- Pre-hook input modification is forwarded to agent
+- Post-hook is called after agent run
+- force_legacy_orchestrator bypasses hooks
+- Canary routing is skipped when enable_new_orchestrator is False
+- Shadow-mode check in orchestrator._run_phase delegation
+"""
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from core.phase_dispatcher import PhaseDispatcher
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_agent(return_value=None):
+    agent = MagicMock()
+    agent.run.return_value = return_value or {"status": "ok"}
+    return agent
+
+
+def _make_hook_engine(should_proceed=True, modified_input=None):
+    """Return a mock HookEngine.
+
+    run_pre_hooks returns (should_proceed, input_data).
+    run_post_hooks returns None (observational).
+    """
+    hook_engine = MagicMock()
+    hook_engine.run_pre_hooks.side_effect = lambda phase, data: (
+        should_proceed,
+        modified_input if modified_input is not None else data,
+    )
+    hook_engine.run_post_hooks.return_value = None
+    return hook_engine
+
+
+# ---------------------------------------------------------------------------
+# Basic dispatch
+# ---------------------------------------------------------------------------
+
+class TestPhaseDispatcherBasic(unittest.TestCase):
+    def test_dispatch_calls_registered_agent(self):
+        agent = _make_agent({"result": "planned"})
+        dispatcher = PhaseDispatcher(
+            agents={"plan": agent},
+            hook_engine=_make_hook_engine(),
+        )
+        result = dispatcher.dispatch("plan", {"goal": "test"})
+        agent.run.assert_called_once_with({"goal": "test"})
+        self.assertEqual(result, {"result": "planned"})
+
+    def test_dispatch_returns_empty_dict_when_no_agent(self):
+        dispatcher = PhaseDispatcher(
+            agents={},
+            hook_engine=_make_hook_engine(),
+        )
+        result = dispatcher.dispatch("act", {"task": "something"})
+        self.assertEqual(result, {})
+
+    def test_dispatch_with_no_hook_engine(self):
+        """When hook_engine is None hooks are skipped gracefully."""
+        agent = _make_agent({"done": True})
+        dispatcher = PhaseDispatcher(agents={"verify": agent}, hook_engine=None)
+        result = dispatcher.dispatch("verify", {"change_set": {}})
+        agent.run.assert_called_once()
+        self.assertEqual(result, {"done": True})
+
+
+# ---------------------------------------------------------------------------
+# Hook integration
+# ---------------------------------------------------------------------------
+
+class TestPhaseDispatcherHooks(unittest.TestCase):
+    def test_pre_hook_blocking_returns_sentinel(self):
+        agent = _make_agent()
+        hook_engine = _make_hook_engine(should_proceed=False)
+        dispatcher = PhaseDispatcher(
+            agents={"plan": agent},
+            hook_engine=hook_engine,
+        )
+        result = dispatcher.dispatch("plan", {"goal": "blocked"})
+        agent.run.assert_not_called()
+        self.assertEqual(result, {"_blocked_by_hook": True, "phase": "plan"})
+
+    def test_pre_hook_can_modify_input_data(self):
+        """Modified input from pre-hook is forwarded to the agent."""
+        agent = _make_agent()
+        modified = {"goal": "injected by hook"}
+        hook_engine = _make_hook_engine(should_proceed=True, modified_input=modified)
+        dispatcher = PhaseDispatcher(
+            agents={"plan": agent},
+            hook_engine=hook_engine,
+        )
+        dispatcher.dispatch("plan", {"goal": "original"})
+        agent.run.assert_called_once_with(modified)
+
+    def test_post_hook_called_with_agent_result(self):
+        agent_result = {"status": "pass", "logs": "all ok"}
+        agent = _make_agent(agent_result)
+        hook_engine = _make_hook_engine()
+        dispatcher = PhaseDispatcher(
+            agents={"verify": agent},
+            hook_engine=hook_engine,
+        )
+        dispatcher.dispatch("verify", {})
+        hook_engine.run_post_hooks.assert_called_once_with("verify", agent_result)
+
+    def test_post_hook_receives_empty_dict_when_agent_returns_non_dict(self):
+        agent = MagicMock()
+        agent.run.return_value = "not a dict"
+        hook_engine = _make_hook_engine()
+        dispatcher = PhaseDispatcher(
+            agents={"reflect": agent},
+            hook_engine=hook_engine,
+        )
+        dispatcher.dispatch("reflect", {})
+        hook_engine.run_post_hooks.assert_called_once_with("reflect", {})
+
+    def test_post_hook_not_called_when_blocked(self):
+        hook_engine = _make_hook_engine(should_proceed=False)
+        dispatcher = PhaseDispatcher(
+            agents={"plan": _make_agent()},
+            hook_engine=hook_engine,
+        )
+        dispatcher.dispatch("plan", {})
+        hook_engine.run_post_hooks.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Legacy bypass
+# ---------------------------------------------------------------------------
+
+class TestPhaseDispatcherLegacyBypass(unittest.TestCase):
+    def test_force_legacy_skips_hooks(self):
+        agent = _make_agent({"legacy": True})
+        hook_engine = _make_hook_engine()
+        dispatcher = PhaseDispatcher(
+            agents={"act": agent},
+            hook_engine=hook_engine,
+            config={"force_legacy_orchestrator": True},
+        )
+        result = dispatcher.dispatch("act", {"task": "x"})
+        hook_engine.run_pre_hooks.assert_not_called()
+        hook_engine.run_post_hooks.assert_not_called()
+        self.assertEqual(result, {"legacy": True})
+
+    def test_force_legacy_no_agent_returns_empty(self):
+        dispatcher = PhaseDispatcher(
+            agents={},
+            hook_engine=_make_hook_engine(),
+            config={"force_legacy_orchestrator": True},
+        )
+        result = dispatcher.dispatch("missing", {})
+        self.assertEqual(result, {})
+
+
+# ---------------------------------------------------------------------------
+# Canary routing (unit-level — canary disabled)
+# ---------------------------------------------------------------------------
+
+class TestPhaseDispatcherCanary(unittest.TestCase):
+    def test_canary_not_triggered_without_flag(self):
+        """CANARY_PHASES fall through to synchronous agent when flag is off."""
+        agent = _make_agent({"discovered": True})
+        dispatcher = PhaseDispatcher(
+            agents={"mcp_discovery": agent},
+            hook_engine=_make_hook_engine(),
+            config={},  # enable_new_orchestrator absent
+        )
+        result = dispatcher.dispatch("mcp_discovery", {})
+        agent.run.assert_called_once()
+        self.assertEqual(result, {"discovered": True})
+
+    def test_non_canary_phase_never_routes_to_async(self):
+        """Non-canary phases are never routed async even when flag is set."""
+        agent = _make_agent({"planned": True})
+        dispatcher = PhaseDispatcher(
+            agents={"plan": agent},
+            hook_engine=_make_hook_engine(),
+            config={"enable_new_orchestrator": True},
+        )
+        result = dispatcher.dispatch("plan", {})
+        agent.run.assert_called_once()
+        self.assertEqual(result, {"planned": True})
+
+
+# ---------------------------------------------------------------------------
+# Config propagation
+# ---------------------------------------------------------------------------
+
+class TestPhaseDispatcherConfig(unittest.TestCase):
+    def test_default_config_is_empty_dict(self):
+        dispatcher = PhaseDispatcher(agents={})
+        self.assertEqual(dispatcher._config, {})
+
+    def test_project_root_defaults_to_dot(self):
+        dispatcher = PhaseDispatcher(agents={})
+        self.assertEqual(dispatcher.project_root, ".")
+
+    def test_custom_project_root_stored(self):
+        dispatcher = PhaseDispatcher(agents={}, project_root="/my/project")
+        self.assertEqual(dispatcher.project_root, "/my/project")
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator delegation smoke test
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorDelegation(unittest.TestCase):
+    """Verify that LoopOrchestrator._run_phase delegates to PhaseDispatcher."""
+
+    def _make_orchestrator(self):
+        from pathlib import Path
+        from core.orchestrator import LoopOrchestrator
+
+        agents = {
+            "ingest": _make_agent({"context": "ok"}),
+            "plan": _make_agent({"steps": ["step1"]}),
+            "critique": _make_agent({"issues": []}),
+            "synthesize": _make_agent({"tasks": []}),
+            "act": _make_agent({"changes": []}),
+            "verify": _make_agent({"status": "pass", "failures": [], "logs": ""}),
+            "reflect": _make_agent({"summary": "done"}),
+        }
+        orc = LoopOrchestrator(agents=agents, project_root=Path("/tmp"))
+        return orc
+
+    def test_run_phase_delegates_to_phase_dispatcher(self):
+        orc = self._make_orchestrator()
+        # Patch the dispatcher's dispatch method
+        orc._phase_dispatcher.dispatch = MagicMock(return_value={"patched": True})
+        result = orc._run_phase("plan", {"goal": "test"})
+        orc._phase_dispatcher.dispatch.assert_called_once_with("plan", {"goal": "test"})
+        self.assertEqual(result, {"patched": True})
+
+    def test_run_phase_shadow_check_skipped_when_blocked_by_hook(self):
+        orc = self._make_orchestrator()
+        orc._phase_dispatcher.dispatch = MagicMock(
+            return_value={"_blocked_by_hook": True, "phase": "plan"}
+        )
+        with patch.object(orc, "_run_shadow_check") as mock_shadow:
+            orc._run_phase("plan", {})
+            mock_shadow.assert_not_called()
+
+    def test_phase_dispatcher_instantiated_on_orchestrator(self):
+        orc = self._make_orchestrator()
+        self.assertIsInstance(orc._phase_dispatcher, PhaseDispatcher)
+
+    def test_phase_dispatcher_uses_same_agents(self):
+        orc = self._make_orchestrator()
+        self.assertIs(orc._phase_dispatcher.agents, orc.agents)
+
+    def test_phase_dispatcher_uses_same_hook_engine(self):
+        orc = self._make_orchestrator()
+        self.assertIs(orc._phase_dispatcher.hook_engine, orc.hook_engine)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Extract phase dispatch logic into core/phase_dispatcher.py
- Wire into orchestrator via delegation (no behavior change)
- Document execution pattern overlap with workflow_engine.py

Closes #330, #331

## Test plan
- [ ] 20 PhaseDispatcher tests pass
- [ ] Orchestrator integration tests pass
- [ ] No regressions