### PR TITLE
fix: GoalQueue InFlightTracker prevents goal loss on interrupt

### DIFF
--- a/core/goal_queue.py
+++ b/core/goal_queue.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections import deque
 from pathlib import Path # Import Path
 from core.logging_utils import log_json # Import log_json
@@ -8,6 +9,12 @@ class GoalQueue:
     Manages a persistent queue of goals for the AURA system. Goals are stored
     in a JSON file and loaded/saved automatically, ensuring work continuity
     across sessions.
+
+    An in-flight tracker prevents silent goal loss on crash or interrupt: goals
+    moved out of the queue by :meth:`next` are kept in ``_in_flight`` until
+    :meth:`complete` or :meth:`fail` is called.  On startup, call
+    :meth:`recover` to push any stale in-flight entries back to the front of
+    the queue.
     """
 
     def __init__(self, queue_path="memory/goal_queue.json"):
@@ -20,7 +27,14 @@ class GoalQueue:
         """
         self.queue_path = Path(queue_path) # Convert to Path object
         self.queue_path.parent.mkdir(parents=True, exist_ok=True)
-        self.queue = self._load_queue() # Load into a deque
+        data = self._load_data()
+        self.queue = deque(data.get("queue", []))
+        # _in_flight: dict mapping goal (str) → unix timestamp (float)
+        self._in_flight: dict[str, float] = data.get("in_flight", {})
+
+    # ------------------------------------------------------------------
+    # Public queue operations
+    # ------------------------------------------------------------------
 
     def add(self, goal):
         """
@@ -57,16 +71,20 @@ class GoalQueue:
 
     def next(self):
         """
-        Retrieves and removes the next goal from the front of the queue.
+        Retrieves the next goal from the front of the queue and moves it to
+        the in-flight tracker instead of deleting it.
+
+        The goal remains in ``_in_flight`` until the caller invokes
+        :meth:`complete` (success) or :meth:`fail` (failure/retry).
 
         Returns:
             The next goal in the queue, or None if the queue is empty.
         """
         if self.queue:
-            goal = self.queue.popleft() # Optimized pop
+            goal = self.queue.popleft()
+            self._in_flight[goal] = time.time()
             self._save_queue()
             return goal
-
 
     def has_goals(self):
         """
@@ -84,29 +102,113 @@ class GoalQueue:
         self.queue.clear()
         self._save_queue()
 
+    # ------------------------------------------------------------------
+    # In-flight lifecycle methods
+    # ------------------------------------------------------------------
+
+    def complete(self, goal):
+        """Remove a goal from the in-flight tracker after successful execution.
+
+        Args:
+            goal: The goal that finished successfully.
+        """
+        if goal in self._in_flight:
+            del self._in_flight[goal]
+            self._save_queue()
+            log_json("INFO", "goal_completed", details={"goal": str(goal)[:120]})
+        else:
+            log_json("WARN", "goal_complete_not_inflight", details={"goal": str(goal)[:120]})
+
+    def fail(self, goal):
+        """Move a goal from in-flight back to the front of the queue for retry.
+
+        Args:
+            goal: The goal that failed and should be retried.
+        """
+        if goal in self._in_flight:
+            del self._in_flight[goal]
+        self.queue.appendleft(goal)
+        self._save_queue()
+        log_json("INFO", "goal_requeued_after_failure", details={"goal": str(goal)[:120]})
+
+    def recover(self):
+        """Restore any in-flight goals to the front of the queue.
+
+        Call this once on startup after a crash or unclean shutdown to prevent
+        silent goal loss.  Goals are prepended in their original insertion order
+        (oldest first) so that work resumes naturally.
+
+        Returns:
+            int: Number of goals recovered.
+        """
+        if not self._in_flight:
+            return 0
+
+        # Sort by timestamp so oldest in-flight goal ends up first
+        recovered = sorted(self._in_flight.keys(), key=lambda g: self._in_flight[g])
+        count = len(recovered)
+        self._in_flight = {}
+        for goal in reversed(recovered):
+            self.queue.appendleft(goal)
+        self._save_queue()
+        log_json("INFO", "goal_queue_recovered", details={"count": count})
+        return count
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    # ------------------------------------------------------------------
+
     def _save_queue(self):
         """
-        Persists the current state of the goal queue to the configured JSON file.
-        Uses a compact encoding because this path is on the hot add/pop loop.
+        Persists the current state of the goal queue and in-flight tracker to
+        the configured JSON file.  Uses a compact encoding because this path is
+        on the hot add/pop loop.
         """
         self.queue_path.write_text(
-            json.dumps(list(self.queue), separators=(",", ":")),
+            json.dumps(
+                {"queue": list(self.queue), "in_flight": self._in_flight},
+                separators=(",", ":"),
+            ),
             encoding="utf-8",
         )
 
-    def _load_queue(self):
+    def _load_data(self) -> dict:
         """
-        Loads the goal queue from the configured JSON file.
-        If the file does not exist or is corrupted, it initializes an empty queue.
+        Loads queue state from the configured JSON file.
+
+        Supports both the legacy format (plain JSON array) and the new format
+        (dict with ``queue`` and ``in_flight`` keys) so that existing deployments
+        are not broken on upgrade.
 
         Returns:
-            collections.deque: The loaded goal queue.
+            dict with keys ``queue`` (list) and ``in_flight`` (dict).
         """
-        if self.queue_path.exists(): # Use Path.exists()
-            with self.queue_path.open('r', encoding='utf-8') as f:
+        if self.queue_path.exists():
+            with self.queue_path.open("r", encoding="utf-8") as f:
                 try:
-                    return deque(json.load(f))
+                    raw = json.load(f)
                 except json.JSONDecodeError:
-                    log_json("WARN", "goal_queue_corrupted", details={"path": str(self.queue_path), "message": "Starting with empty queue."})
-                    return deque()
-        return deque()
+                    log_json(
+                        "WARN",
+                        "goal_queue_corrupted",
+                        details={"path": str(self.queue_path), "message": "Starting with empty queue."},
+                    )
+                    return {"queue": [], "in_flight": {}}
+
+            # Legacy format: plain list
+            if isinstance(raw, list):
+                return {"queue": raw, "in_flight": {}}
+
+            # New format
+            if isinstance(raw, dict):
+                return {
+                    "queue": raw.get("queue", []),
+                    "in_flight": raw.get("in_flight", {}),
+                }
+
+        return {"queue": [], "in_flight": {}}
+
+    # Keep private alias for any external callers that relied on _load_queue
+    def _load_queue(self):
+        """Backward-compatible shim — returns a deque of queued goals only."""
+        return deque(self._load_data()["queue"])

--- a/tests/test_goal_queue_inflight.py
+++ b/tests/test_goal_queue_inflight.py
@@ -1,0 +1,191 @@
+"""
+Tests for GoalQueue InFlightTracker (Issue #301).
+
+Verifies that next() moves goals to in_flight instead of deleting them,
+complete() removes from in_flight, fail() re-queues at front, recover()
+restores all in-flight goals, and that state is persisted across save/load.
+"""
+from __future__ import annotations
+
+import json
+import pytest
+from pathlib import Path
+from core.goal_queue import GoalQueue
+
+
+@pytest.fixture
+def queue_file(tmp_path) -> Path:
+    return tmp_path / "test_goal_queue.json"
+
+
+@pytest.fixture
+def gq(queue_file) -> GoalQueue:
+    return GoalQueue(queue_path=str(queue_file))
+
+
+class TestNextMovesToInFlight:
+    def test_next_removes_from_queue(self, gq):
+        gq.add("goal-a")
+        gq.next()
+        assert not gq.has_goals()
+
+    def test_next_places_in_inflight(self, gq):
+        gq.add("goal-a")
+        goal = gq.next()
+        assert goal == "goal-a"
+        assert "goal-a" in gq._in_flight
+
+    def test_next_on_empty_returns_none(self, gq):
+        assert gq.next() is None
+        assert gq._in_flight == {}
+
+    def test_next_records_timestamp(self, gq):
+        import time
+        before = time.time()
+        gq.add("goal-b")
+        gq.next()
+        after = time.time()
+        ts = gq._in_flight["goal-b"]
+        assert before <= ts <= after
+
+
+class TestComplete:
+    def test_complete_removes_from_inflight(self, gq):
+        gq.add("goal-a")
+        gq.next()
+        assert "goal-a" in gq._in_flight
+        gq.complete("goal-a")
+        assert "goal-a" not in gq._in_flight
+
+    def test_complete_does_not_requeue(self, gq):
+        gq.add("goal-a")
+        gq.next()
+        gq.complete("goal-a")
+        assert not gq.has_goals()
+
+    def test_complete_unknown_goal_does_not_raise(self, gq):
+        # Should warn but not raise
+        gq.complete("nonexistent-goal")
+
+
+class TestFail:
+    def test_fail_removes_from_inflight(self, gq):
+        gq.add("goal-a")
+        gq.next()
+        gq.fail("goal-a")
+        assert "goal-a" not in gq._in_flight
+
+    def test_fail_puts_goal_at_front_of_queue(self, gq):
+        gq.add("goal-a")
+        gq.add("goal-b")
+        first = gq.next()
+        assert first == "goal-a"
+        gq.fail("goal-a")
+        # goal-a should now be at the front, before goal-b
+        assert gq.next() == "goal-a"
+        assert gq.next() == "goal-b"
+
+    def test_fail_goal_not_inflight_still_requeues(self, gq):
+        """fail() should tolerate goals not currently in _in_flight."""
+        gq.fail("orphan-goal")
+        assert gq.next() == "orphan-goal"
+
+
+class TestRecover:
+    def test_recover_moves_inflight_to_front(self, gq):
+        gq.add("goal-a")
+        gq.add("goal-b")
+        gq.next()  # goal-a goes in_flight
+        # Add another goal after popping
+        gq.add("goal-c")
+        count = gq.recover()
+        assert count == 1
+        # goal-a should be back at front
+        assert gq.next() == "goal-a"
+
+    def test_recover_clears_inflight(self, gq):
+        gq.add("goal-a")
+        gq.next()
+        gq.recover()
+        assert gq._in_flight == {}
+
+    def test_recover_multiple_inflight_oldest_first(self, gq):
+        import time
+        gq.add("goal-x")
+        gq.add("goal-y")
+        # Manually set timestamps so order is deterministic
+        goal_x = gq.next()
+        time.sleep(0.01)
+        goal_y = gq.next()
+        count = gq.recover()
+        assert count == 2
+        # Oldest (goal-x) should be at front
+        assert gq.next() == goal_x
+        assert gq.next() == goal_y
+
+    def test_recover_empty_inflight_returns_zero(self, gq):
+        gq.add("goal-a")
+        assert gq.recover() == 0
+        # Queue untouched
+        assert gq.next() == "goal-a"
+
+
+class TestPersistence:
+    def test_inflight_persisted_to_json(self, queue_file):
+        gq = GoalQueue(queue_path=str(queue_file))
+        gq.add("goal-a")
+        gq.next()
+
+        raw = json.loads(queue_file.read_text())
+        assert isinstance(raw, dict)
+        assert "in_flight" in raw
+        assert "goal-a" in raw["in_flight"]
+
+    def test_queue_persisted_alongside_inflight(self, queue_file):
+        gq = GoalQueue(queue_path=str(queue_file))
+        gq.add("goal-a")
+        gq.add("goal-b")
+        gq.next()
+
+        raw = json.loads(queue_file.read_text())
+        assert raw["queue"] == ["goal-b"]
+        assert "goal-a" in raw["in_flight"]
+
+    def test_reload_restores_inflight(self, queue_file):
+        gq = GoalQueue(queue_path=str(queue_file))
+        gq.add("goal-a")
+        gq.next()
+
+        # Reload from disk
+        gq2 = GoalQueue(queue_path=str(queue_file))
+        assert "goal-a" in gq2._in_flight
+
+    def test_reload_then_recover(self, queue_file):
+        gq = GoalQueue(queue_path=str(queue_file))
+        gq.add("goal-a")
+        gq.add("goal-b")
+        gq.next()  # goal-a in flight
+
+        # Simulate restart
+        gq2 = GoalQueue(queue_path=str(queue_file))
+        count = gq2.recover()
+        assert count == 1
+        # goal-a back at front, goal-b behind it
+        assert gq2.next() == "goal-a"
+        assert gq2.next() == "goal-b"
+
+    def test_legacy_format_loads_as_empty_inflight(self, queue_file):
+        """Plain JSON array (old format) should load without in_flight entries."""
+        queue_file.write_text(json.dumps(["goal-old-a", "goal-old-b"]), encoding="utf-8")
+        gq = GoalQueue(queue_path=str(queue_file))
+        assert list(gq.queue) == ["goal-old-a", "goal-old-b"]
+        assert gq._in_flight == {}
+
+    def test_complete_removes_from_persisted_inflight(self, queue_file):
+        gq = GoalQueue(queue_path=str(queue_file))
+        gq.add("goal-a")
+        gq.next()
+        gq.complete("goal-a")
+
+        raw = json.loads(queue_file.read_text())
+        assert "goal-a" not in raw.get("in_flight", {})


### PR DESCRIPTION
## Summary
- Goals moved to in_flight state during execution (not deleted)
- complete() removes from in_flight after success
- fail() returns goal to front of queue for retry
- recover() restores all in-flight goals on startup after crash
- Persisted to same JSON file as queue

Closes #301

## Test plan
- [ ] 20 new inflight tracker tests pass
- [ ] Existing goal_queue tests pass