### PR TITLE
feat: LessonStore — cycle learning persistence

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -164,6 +164,12 @@ class LoopOrchestrator:
         self.config = config
         self.debugger = debugger  # Optional DebuggerAgent for auto-recovery
         self.human_gate = HumanGate()
+        self.lesson_store = None
+        try:
+            from memory.lesson_store import LessonStore
+            self.lesson_store = LessonStore()
+        except Exception:
+            pass
         self.auto_add_capabilities = auto_add_capabilities
         self.auto_queue_missing_capabilities = auto_queue_missing_capabilities
         self.auto_provision_mcp = auto_provision_mcp
@@ -1633,6 +1639,15 @@ class LoopOrchestrator:
         pipeline_cfg = self._configure_pipeline(goal, goal_type, phase_outputs)
         self._handle_capabilities(goal, pipeline_cfg, phase_outputs, dry_run)
 
+        # Inject lessons from previous cycles into planner context
+        if self.lesson_store:
+            try:
+                lessons = self.lesson_store.injectable_lessons()
+                if lessons:
+                    phase_outputs["injected_lessons"] = lessons
+            except Exception:
+                pass
+
         context = self._run_ingest_phase(goal, cycle_id, phase_outputs)
         if self.strict_schema and validate_phase_output("context", context):
             return self._build_early_stop_entry(
@@ -1727,7 +1742,16 @@ class LoopOrchestrator:
         phase_outputs["cycle_confidence"] = self.confidence_router.get_cycle_confidence()
 
         phase_outputs.pop("_failure_context", None)
-        return self._record_cycle_outcome(cycle_id, goal, goal_type, phase_outputs, started_at)
+        result = self._record_cycle_outcome(cycle_id, goal, goal_type, phase_outputs, started_at)
+
+        # Record lesson from this cycle
+        if self.lesson_store:
+            try:
+                self.lesson_store.record_cycle(result)
+            except Exception:
+                pass
+
+        return result
 
     def _estimate_confidence(self, output: Dict, phase: str) -> float:
         """Heuristically estimate confidence for a phase output.

--- a/memory/lesson_store.py
+++ b/memory/lesson_store.py
@@ -1,0 +1,106 @@
+"""LessonStore — persistent cycle lessons for the AURA orchestrator.
+
+Records outcomes from each orchestrator cycle and makes injectable
+lessons available to the planner at the start of subsequent cycles.
+"""
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class LessonStore:
+    """Stores and retrieves lessons learned from orchestrator cycles.
+
+    Lessons are persisted as JSONL in ``memory/lessons.jsonl``.  Each entry
+    records the goal, outcome, failure reasons, and any insights that the
+    reflector or skill dispatcher surfaced.
+
+    Args:
+        store_path: Path to the JSONL file. Defaults to ``memory/lessons.jsonl``.
+        max_injectable: Maximum number of recent lessons to inject into the
+            planner prompt.  Older lessons are still stored but not injected.
+    """
+
+    def __init__(self, store_path: Optional[Path] = None, max_injectable: int = 5):
+        self.store_path = Path(store_path or "memory/lessons.jsonl")
+        self.max_injectable = max_injectable
+        self._lessons: List[Dict[str, Any]] = []
+        self._load()
+
+    def _load(self) -> None:
+        """Load existing lessons from disk."""
+        if not self.store_path.exists():
+            return
+        try:
+            for line in self.store_path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line:
+                    self._lessons.append(json.loads(line))
+        except (json.JSONDecodeError, OSError):
+            pass  # Start fresh on corruption
+
+    def _save_entry(self, entry: Dict[str, Any]) -> None:
+        """Append a single entry to the JSONL file."""
+        self.store_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(self.store_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(entry, default=str) + "\n")
+
+    def record_cycle(self, cycle_result: Dict[str, Any]) -> None:
+        """Record a lesson from a completed cycle.
+
+        Extracts the goal, stop_reason, phase outcomes, and any insights
+        from the cycle result dict.
+
+        Args:
+            cycle_result: The dict returned by ``LoopOrchestrator.run_cycle()``.
+        """
+        entry = {
+            "timestamp": time.time(),
+            "goal": cycle_result.get("goal", ""),
+            "goal_type": cycle_result.get("goal_type", ""),
+            "stop_reason": cycle_result.get("stop_reason", ""),
+            "status": cycle_result.get("status", ""),
+            "verify_status": cycle_result.get("phase_outputs", {}).get("verify", {}).get("status", ""),
+            "cycle_confidence": cycle_result.get("phase_outputs", {}).get("cycle_confidence", 0),
+            "failure_context": cycle_result.get("phase_outputs", {}).get("_failure_context", ""),
+        }
+        self._lessons.append(entry)
+        self._save_entry(entry)
+
+    def injectable_lessons(self) -> List[Dict[str, Any]]:
+        """Return recent lessons suitable for injection into planner context.
+
+        Returns the most recent ``max_injectable`` lessons, formatted
+        for inclusion in the planner's input data.
+        """
+        recent = self._lessons[-self.max_injectable:]
+        return [
+            {
+                "goal": l.get("goal", ""),
+                "outcome": l.get("stop_reason", ""),
+                "confidence": l.get("cycle_confidence", 0),
+                "lesson": _derive_lesson(l),
+            }
+            for l in recent
+        ]
+
+    def count(self) -> int:
+        """Return the total number of stored lessons."""
+        return len(self._lessons)
+
+
+def _derive_lesson(entry: Dict[str, Any]) -> str:
+    """Derive a human-readable lesson from a cycle entry."""
+    stop = entry.get("stop_reason", "")
+    verify = entry.get("verify_status", "")
+    goal = entry.get("goal", "unknown")
+
+    if stop == "MAX_CYCLES":
+        return f"Goal '{goal[:50]}' hit max cycles — consider decomposing into smaller steps."
+    if verify == "fail":
+        return f"Goal '{goal[:50]}' failed verification — check test expectations."
+    if verify == "pass":
+        return f"Goal '{goal[:50]}' succeeded — similar approach may work for related goals."
+    return f"Goal '{goal[:50]}' completed with stop_reason={stop}."

--- a/tests/test_lesson_store.py
+++ b/tests/test_lesson_store.py
@@ -1,0 +1,99 @@
+"""Tests for memory/lesson_store.py — LessonStore persistence and injection."""
+import json
+import pytest
+from pathlib import Path
+from memory.lesson_store import LessonStore, _derive_lesson
+
+
+class TestLessonStoreBasic:
+    def test_create_empty_store(self, tmp_path):
+        store = LessonStore(store_path=tmp_path / "lessons.jsonl")
+        assert store.count() == 0
+
+    def test_record_and_count(self, tmp_path):
+        store = LessonStore(store_path=tmp_path / "lessons.jsonl")
+        store.record_cycle({"goal": "test goal", "stop_reason": "done"})
+        assert store.count() == 1
+
+    def test_record_persists_to_disk(self, tmp_path):
+        path = tmp_path / "lessons.jsonl"
+        store = LessonStore(store_path=path)
+        store.record_cycle({"goal": "persist test", "stop_reason": "done"})
+        assert path.exists()
+        lines = path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["goal"] == "persist test"
+
+    def test_load_on_init(self, tmp_path):
+        path = tmp_path / "lessons.jsonl"
+        store1 = LessonStore(store_path=path)
+        store1.record_cycle({"goal": "a"})
+        store1.record_cycle({"goal": "b"})
+        store2 = LessonStore(store_path=path)
+        assert store2.count() == 2
+
+
+class TestInjectableLessons:
+    def test_returns_empty_when_no_lessons(self, tmp_path):
+        store = LessonStore(store_path=tmp_path / "l.jsonl")
+        assert store.injectable_lessons() == []
+
+    def test_returns_recent_lessons(self, tmp_path):
+        store = LessonStore(store_path=tmp_path / "l.jsonl", max_injectable=2)
+        for i in range(5):
+            store.record_cycle({"goal": f"goal-{i}", "stop_reason": "done"})
+        lessons = store.injectable_lessons()
+        assert len(lessons) == 2
+        assert lessons[0]["goal"] == "goal-3"
+        assert lessons[1]["goal"] == "goal-4"
+
+    def test_lesson_format(self, tmp_path):
+        store = LessonStore(store_path=tmp_path / "l.jsonl")
+        store.record_cycle({"goal": "test", "stop_reason": "done", "phase_outputs": {"cycle_confidence": 0.8}})
+        lessons = store.injectable_lessons()
+        assert len(lessons) == 1
+        assert "goal" in lessons[0]
+        assert "outcome" in lessons[0]
+        assert "lesson" in lessons[0]
+
+
+class TestDeriveLesson:
+    def test_max_cycles_lesson(self):
+        result = _derive_lesson({"goal": "big task", "stop_reason": "MAX_CYCLES"})
+        assert "decomposing" in result
+
+    def test_verify_fail_lesson(self):
+        result = _derive_lesson({"goal": "buggy", "verify_status": "fail"})
+        assert "verification" in result
+
+    def test_verify_pass_lesson(self):
+        result = _derive_lesson({"goal": "good", "verify_status": "pass"})
+        assert "succeeded" in result
+
+
+class TestCorruptionResilience:
+    def test_corrupt_file_doesnt_crash(self, tmp_path):
+        path = tmp_path / "l.jsonl"
+        path.write_text("not json\n{bad\n")
+        store = LessonStore(store_path=path)
+        assert store.count() == 0
+
+    def test_missing_file_starts_empty(self, tmp_path):
+        store = LessonStore(store_path=tmp_path / "nonexistent.jsonl")
+        assert store.count() == 0
+
+
+class TestOrchestratorIntegration:
+    def test_none_lesson_store_doesnt_crash(self):
+        """Orchestrator should handle lesson_store=None gracefully."""
+        from unittest.mock import MagicMock, patch
+        from core.orchestrator import LoopOrchestrator
+
+        with patch.object(LoopOrchestrator, '__init__', lambda self, **kw: None):
+            orch = LoopOrchestrator()
+            orch.lesson_store = None
+            # Simulate the guard pattern used in run_cycle
+            if orch.lesson_store:
+                orch.lesson_store.injectable_lessons()
+            # Should not raise


### PR DESCRIPTION
## Summary
- New `memory/lesson_store.py` with JSONL persistence
- Orchestrator injects recent lessons into planner context at cycle start
- Records cycle outcomes at cycle end for future learning
- Corruption-resilient (handles corrupt/missing files)

Closes #309

## Test plan
- [ ] 13 new LessonStore tests pass
- [ ] Orchestrator integration tests pass