### PR TITLE
feat: JSON-RPC stdio transport (#209)

### DIFF
--- a/core/transport.py
+++ b/core/transport.py
@@ -1,0 +1,291 @@
+"""JSON-RPC 2.0 over stdio transport for the AURA orchestrator.
+
+Reads line-delimited JSON-RPC 2.0 requests from stdin and writes responses to
+stdout.  Each line is a complete JSON object; responses are also written one
+per line.
+
+JSON-RPC 2.0 quick reference:
+  Request:  {"jsonrpc": "2.0", "id": 1, "method": "goal/run", "params": {...}}
+  Response: {"jsonrpc": "2.0", "id": 1, "result": {...}}
+  Error:    {"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "..."}}
+  Notification (no response): {"jsonrpc": "2.0", "method": "...", "params": {...}}
+
+Supported methods:
+  goal/run       — run a goal through the orchestrator
+  goal/add       — add a goal to the queue
+  goal/status    — return current orchestrator status
+  system/health  — health check
+
+Standard error codes:
+  -32700  Parse error
+  -32600  Invalid request
+  -32601  Method not found
+  -32000  Server error (orchestrator or handler exception)
+"""
+
+import json
+import sys
+import datetime
+from typing import Any, Callable, Dict, Optional
+
+
+# ---------------------------------------------------------------------------
+# Error code constants (JSON-RPC 2.0)
+# ---------------------------------------------------------------------------
+PARSE_ERROR = -32700
+INVALID_REQUEST = -32600
+METHOD_NOT_FOUND = -32601
+SERVER_ERROR = -32000
+
+
+class StdioTransport:
+    """JSON-RPC 2.0 over stdio transport for AURA orchestrator.
+
+    Reads newline-delimited JSON from stdin and writes newline-delimited JSON
+    responses to stdout.  Notifications (requests without an ``id`` field) are
+    processed but do not produce a response.
+
+    Args:
+        orchestrator: An optional :class:`~core.orchestrator.LoopOrchestrator`
+            instance.  When *None* the transport still handles ``system/health``
+            and ``goal/status`` but will return a server error for methods that
+            require an active orchestrator.
+        stdin: Readable stream to consume requests from.  Defaults to
+            ``sys.stdin``.
+        stdout: Writable stream to emit responses to.  Defaults to
+            ``sys.stdout``.
+    """
+
+    def __init__(
+        self,
+        orchestrator=None,
+        stdin=None,
+        stdout=None,
+    ) -> None:
+        self.orchestrator = orchestrator
+        self._stdin = stdin if stdin is not None else sys.stdin
+        self._stdout = stdout if stdout is not None else sys.stdout
+        self._methods: Dict[str, Callable[[Any], Any]] = {
+            "goal/run": self._handle_goal_run,
+            "goal/add": self._handle_goal_add,
+            "goal/status": self._handle_goal_status,
+            "system/health": self._handle_system_health,
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        """Read JSON-RPC requests from stdin, write responses to stdout.
+
+        Runs until EOF.  Each line is processed independently; a malformed line
+        produces a parse-error response but does not stop the loop.
+        """
+        for raw_line in self._stdin:
+            raw_line = raw_line.rstrip("\n")
+            if not raw_line:
+                continue
+            response = self._process_line(raw_line)
+            if response is not None:
+                self._write_response(response)
+
+    def dispatch(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Process a single parsed request dict and return the response dict.
+
+        Returns *None* for notifications (requests without an ``id``).
+
+        This is a lower-level entry point useful for testing individual
+        requests without going through the full stdin/stdout loop.
+        """
+        return self._dispatch(request)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _process_line(self, raw_line: str) -> Optional[Dict[str, Any]]:
+        """Parse *raw_line* as JSON and dispatch the resulting request.
+
+        Returns a JSON-RPC response dict, or *None* for notifications.
+        On parse failure returns an error response (with ``id: null``).
+        """
+        try:
+            data = json.loads(raw_line)
+        except (json.JSONDecodeError, ValueError) as exc:
+            return self._error_response(None, PARSE_ERROR, f"Parse error: {exc}")
+
+        return self._dispatch(data)
+
+    def _dispatch(self, data: Any) -> Optional[Dict[str, Any]]:
+        """Validate and route a decoded request object.
+
+        Returns a response dict, or *None* for notifications.
+        """
+        # Spec: id may be absent (notification), string, number, or null.
+        request_id = data.get("id") if isinstance(data, dict) else None
+        is_notification = isinstance(data, dict) and "id" not in data
+
+        # --- validate structure ------------------------------------------------
+        if not isinstance(data, dict):
+            return self._error_response(None, INVALID_REQUEST, "Request must be a JSON object")
+
+        if data.get("jsonrpc") != "2.0":
+            if not is_notification:
+                return self._error_response(request_id, INVALID_REQUEST, "jsonrpc field must be '2.0'")
+            return None
+
+        method = data.get("method")
+        if not method or not isinstance(method, str):
+            if not is_notification:
+                return self._error_response(request_id, INVALID_REQUEST, "method field is required and must be a string")
+            return None
+
+        params = data.get("params", {})
+        if not isinstance(params, (dict, list)):
+            params = {}
+
+        # --- route to handler -------------------------------------------------
+        handler = self._methods.get(method)
+        if handler is None:
+            if is_notification:
+                # Unknown notifications are silently ignored per spec.
+                return None
+            return self._error_response(request_id, METHOD_NOT_FOUND, f"Method not found: {method}")
+
+        try:
+            result = handler(params)
+        except Exception as exc:  # noqa: BLE001
+            if is_notification:
+                return None
+            return self._error_response(request_id, SERVER_ERROR, f"Server error: {exc}")
+
+        # Notifications: process but do not respond.
+        if is_notification:
+            return None
+
+        return self._success_response(request_id, result)
+
+    def _write_response(self, response: Dict[str, Any]) -> None:
+        """Serialise *response* to a single JSON line on stdout."""
+        self._stdout.write(json.dumps(response) + "\n")
+        self._stdout.flush()
+
+    # ------------------------------------------------------------------
+    # Response builders
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _success_response(request_id: Any, result: Any) -> Dict[str, Any]:
+        return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+    @staticmethod
+    def _error_response(request_id: Any, code: int, message: str) -> Dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
+    # ------------------------------------------------------------------
+    # Method handlers
+    # ------------------------------------------------------------------
+
+    def _handle_goal_run(self, params: Any) -> Dict[str, Any]:
+        """Run a goal through the orchestrator.
+
+        Expected params::
+
+            {
+                "goal": "Refactor the auth module",
+                "max_cycles": 5,   # optional, default 5
+                "dry_run": false   # optional, default false
+            }
+
+        Returns the dict produced by :meth:`~core.orchestrator.LoopOrchestrator.run_loop`.
+        """
+        if not isinstance(params, dict):
+            raise ValueError("params must be an object with at least a 'goal' key")
+
+        goal = params.get("goal")
+        if not goal or not isinstance(goal, str):
+            raise ValueError("'goal' param is required and must be a non-empty string")
+
+        if self.orchestrator is None:
+            raise RuntimeError("No orchestrator configured")
+
+        max_cycles = int(params.get("max_cycles", 5))
+        dry_run = bool(params.get("dry_run", False))
+
+        return self.orchestrator.run_loop(goal, max_cycles=max_cycles, dry_run=dry_run)
+
+    def _handle_goal_add(self, params: Any) -> Dict[str, Any]:
+        """Add a goal to the orchestrator's goal queue.
+
+        Expected params::
+
+            {"goal": "Add unit tests for the auth module"}
+
+        Returns ``{"queued": true}``.
+        """
+        if not isinstance(params, dict):
+            raise ValueError("params must be an object with a 'goal' key")
+
+        goal = params.get("goal")
+        if not goal or not isinstance(goal, str):
+            raise ValueError("'goal' param is required and must be a non-empty string")
+
+        if self.orchestrator is None:
+            raise RuntimeError("No orchestrator configured")
+
+        if self.orchestrator.goal_queue is None:
+            raise RuntimeError("Orchestrator has no goal queue")
+
+        self.orchestrator.goal_queue.add(goal)
+        return {"queued": True}
+
+    def _handle_goal_status(self, params: Any) -> Dict[str, Any]:
+        """Return the current orchestrator status.
+
+        Returns a dict with:
+
+        * ``cycle_count``  — number of cycles completed (if available)
+        * ``current_goal`` — the goal currently being processed, or *null*
+        * ``queue_size``   — number of goals waiting in the queue
+        """
+        if self.orchestrator is None:
+            return {
+                "cycle_count": 0,
+                "current_goal": None,
+                "queue_size": 0,
+            }
+
+        cycle_count = 0
+        if hasattr(self.orchestrator, "last_cycle_summary") and self.orchestrator.last_cycle_summary:
+            # Best-effort: extract the cycle index if present.
+            cycle_count = self.orchestrator.last_cycle_summary.get("cycle_index", 0)
+
+        queue_size = 0
+        if self.orchestrator.goal_queue is not None:
+            try:
+                queue_size = len(self.orchestrator.goal_queue)
+            except TypeError:
+                queue_size = 0
+
+        return {
+            "cycle_count": cycle_count,
+            "current_goal": self.orchestrator.current_goal,
+            "queue_size": queue_size,
+        }
+
+    def _handle_system_health(self, params: Any) -> Dict[str, Any]:
+        """Return a simple health-check response.
+
+        Returns::
+
+            {"status": "ok", "timestamp": "<ISO-8601 UTC timestamp>"}
+        """
+        return {
+            "status": "ok",
+            "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+        }

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,307 @@
+"""Tests for core/transport.py — JSON-RPC 2.0 stdio transport."""
+import io
+import json
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.transport import (
+    StdioTransport,
+    PARSE_ERROR,
+    INVALID_REQUEST,
+    METHOD_NOT_FOUND,
+    SERVER_ERROR,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(method, params=None, request_id=1):
+    """Build a minimal valid JSON-RPC 2.0 request dict."""
+    req = {"jsonrpc": "2.0", "id": request_id, "method": method}
+    if params is not None:
+        req["params"] = params
+    return req
+
+
+def _make_orchestrator(current_goal=None, queue_size=0):
+    """Return a MagicMock that mimics LoopOrchestrator's public surface."""
+    orch = MagicMock()
+    orch.current_goal = current_goal
+    orch.last_cycle_summary = None
+    goal_queue = MagicMock()
+    goal_queue.__len__ = MagicMock(return_value=queue_size)
+    orch.goal_queue = goal_queue
+    return orch
+
+
+def _transport(orchestrator=None):
+    return StdioTransport(orchestrator=orchestrator)
+
+
+# ---------------------------------------------------------------------------
+# system/health
+# ---------------------------------------------------------------------------
+
+class TestSystemHealth:
+    def test_health_returns_ok_status(self):
+        t = _transport()
+        result = t.dispatch(_make_request("system/health"))
+        assert result["result"]["status"] == "ok"
+
+    def test_health_returns_timestamp(self):
+        t = _transport()
+        result = t.dispatch(_make_request("system/health"))
+        ts = result["result"]["timestamp"]
+        assert isinstance(ts, str) and ts.endswith("Z")
+
+    def test_health_timestamp_is_parseable_iso8601(self):
+        t = _transport()
+        result = t.dispatch(_make_request("system/health"))
+        ts = result["result"]["timestamp"].rstrip("Z")
+        # Should not raise
+        datetime.datetime.fromisoformat(ts)
+
+    def test_health_no_orchestrator_needed(self):
+        t = _transport(orchestrator=None)
+        result = t.dispatch(_make_request("system/health"))
+        assert result["result"]["status"] == "ok"
+
+    def test_health_response_has_jsonrpc_field(self):
+        t = _transport()
+        result = t.dispatch(_make_request("system/health"))
+        assert result["jsonrpc"] == "2.0"
+
+    def test_health_response_id_matches_request(self):
+        t = _transport()
+        result = t.dispatch(_make_request("system/health", request_id=42))
+        assert result["id"] == 42
+
+
+# ---------------------------------------------------------------------------
+# goal/status
+# ---------------------------------------------------------------------------
+
+class TestGoalStatus:
+    def test_status_no_orchestrator(self):
+        t = _transport(orchestrator=None)
+        result = t.dispatch(_make_request("goal/status"))
+        r = result["result"]
+        assert r["current_goal"] is None
+        assert r["queue_size"] == 0
+        assert r["cycle_count"] == 0
+
+    def test_status_with_current_goal(self):
+        orch = _make_orchestrator(current_goal="Refactor auth")
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/status"))
+        assert result["result"]["current_goal"] == "Refactor auth"
+
+    def test_status_queue_size(self):
+        orch = _make_orchestrator(queue_size=3)
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/status"))
+        assert result["result"]["queue_size"] == 3
+
+    def test_status_cycle_count_from_last_summary(self):
+        orch = _make_orchestrator()
+        orch.last_cycle_summary = {"cycle_index": 7}
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/status"))
+        assert result["result"]["cycle_count"] == 7
+
+    def test_status_cycle_count_zero_when_no_summary(self):
+        orch = _make_orchestrator()
+        orch.last_cycle_summary = None
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/status"))
+        assert result["result"]["cycle_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# goal/add
+# ---------------------------------------------------------------------------
+
+class TestGoalAdd:
+    def test_add_queues_goal(self):
+        orch = _make_orchestrator()
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/add", {"goal": "Add tests"}))
+        orch.goal_queue.add.assert_called_once_with("Add tests")
+        assert result["result"]["queued"] is True
+
+    def test_add_missing_goal_param(self):
+        orch = _make_orchestrator()
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/add", {}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+
+    def test_add_empty_goal_string(self):
+        orch = _make_orchestrator()
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/add", {"goal": ""}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+
+    def test_add_no_orchestrator(self):
+        t = _transport(orchestrator=None)
+        result = t.dispatch(_make_request("goal/add", {"goal": "A goal"}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+
+    def test_add_no_goal_queue(self):
+        orch = _make_orchestrator()
+        orch.goal_queue = None
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/add", {"goal": "A goal"}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+
+
+# ---------------------------------------------------------------------------
+# goal/run
+# ---------------------------------------------------------------------------
+
+class TestGoalRun:
+    def test_run_calls_orchestrator(self):
+        orch = _make_orchestrator()
+        orch.run_loop.return_value = {"goal": "Refactor", "stop_reason": "PASS", "history": []}
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/run", {"goal": "Refactor"}))
+        orch.run_loop.assert_called_once_with("Refactor", max_cycles=5, dry_run=False)
+        assert result["result"]["stop_reason"] == "PASS"
+
+    def test_run_passes_max_cycles(self):
+        orch = _make_orchestrator()
+        orch.run_loop.return_value = {"goal": "x", "stop_reason": "MAX_CYCLES", "history": []}
+        t = _transport(orchestrator=orch)
+        t.dispatch(_make_request("goal/run", {"goal": "x", "max_cycles": 2}))
+        orch.run_loop.assert_called_once_with("x", max_cycles=2, dry_run=False)
+
+    def test_run_passes_dry_run(self):
+        orch = _make_orchestrator()
+        orch.run_loop.return_value = {"goal": "x", "stop_reason": "PASS", "history": []}
+        t = _transport(orchestrator=orch)
+        t.dispatch(_make_request("goal/run", {"goal": "x", "dry_run": True}))
+        orch.run_loop.assert_called_once_with("x", max_cycles=5, dry_run=True)
+
+    def test_run_missing_goal_param(self):
+        orch = _make_orchestrator()
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/run", {}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+
+    def test_run_no_orchestrator(self):
+        t = _transport(orchestrator=None)
+        result = t.dispatch(_make_request("goal/run", {"goal": "Test"}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+
+    def test_run_orchestrator_raises(self):
+        orch = _make_orchestrator()
+        orch.run_loop.side_effect = RuntimeError("boom")
+        t = _transport(orchestrator=orch)
+        result = t.dispatch(_make_request("goal/run", {"goal": "Test"}))
+        assert "error" in result
+        assert result["error"]["code"] == SERVER_ERROR
+        assert "boom" in result["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Error / edge cases
+# ---------------------------------------------------------------------------
+
+class TestErrorHandling:
+    def test_unknown_method_returns_method_not_found(self):
+        t = _transport()
+        result = t.dispatch(_make_request("nonexistent/method"))
+        assert result["error"]["code"] == METHOD_NOT_FOUND
+
+    def test_unknown_method_message_contains_method_name(self):
+        t = _transport()
+        result = t.dispatch(_make_request("nonexistent/method"))
+        assert "nonexistent/method" in result["error"]["message"]
+
+    def test_missing_method_field_returns_invalid_request(self):
+        t = _transport()
+        result = t.dispatch({"jsonrpc": "2.0", "id": 1})
+        assert result["error"]["code"] == INVALID_REQUEST
+
+    def test_wrong_jsonrpc_version_returns_invalid_request(self):
+        t = _transport()
+        result = t.dispatch({"jsonrpc": "1.0", "id": 1, "method": "system/health"})
+        assert result["error"]["code"] == INVALID_REQUEST
+
+    def test_non_dict_request_returns_invalid_request(self):
+        t = _transport()
+        result = t._process_line(json.dumps([1, 2, 3]))
+        assert result["error"]["code"] == INVALID_REQUEST
+
+    def test_invalid_json_returns_parse_error(self):
+        t = _transport()
+        result = t._process_line("{not valid json}")
+        assert result["error"]["code"] == PARSE_ERROR
+
+    def test_parse_error_id_is_null(self):
+        t = _transport()
+        result = t._process_line("broken")
+        assert result["id"] is None
+
+    def test_notification_no_id_returns_none(self):
+        t = _transport()
+        notification = {"jsonrpc": "2.0", "method": "system/health"}
+        result = t.dispatch(notification)
+        assert result is None
+
+    def test_notification_unknown_method_returns_none(self):
+        t = _transport()
+        notification = {"jsonrpc": "2.0", "method": "unknown/method"}
+        result = t.dispatch(notification)
+        assert result is None
+
+    def test_error_response_id_echoes_request_id(self):
+        t = _transport()
+        result = t.dispatch({"jsonrpc": "2.0", "id": 99, "method": "bad/method"})
+        assert result["id"] == 99
+
+
+# ---------------------------------------------------------------------------
+# run() — full stdin/stdout loop
+# ---------------------------------------------------------------------------
+
+class TestRunLoop:
+    def _run_with_lines(self, lines, orchestrator=None):
+        """Feed *lines* (list of str) through transport.run() and return stdout lines."""
+        stdin = io.StringIO("\n".join(lines) + "\n")
+        stdout = io.StringIO()
+        t = StdioTransport(orchestrator=orchestrator, stdin=stdin, stdout=stdout)
+        t.run()
+        stdout.seek(0)
+        return [json.loads(l) for l in stdout.read().splitlines() if l.strip()]
+
+    def test_run_processes_single_health_request(self):
+        req = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "system/health"})
+        responses = self._run_with_lines([req])
+        assert len(responses) == 1
+        assert responses[0]["result"]["status"] == "ok"
+
+    def test_run_processes_multiple_requests(self):
+        r1 = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "system/health"})
+        r2 = json.dumps({"jsonrpc": "2.0", "id": 2, "method": "goal/status"})
+        responses = self._run_with_lines([r1, r2])
+        assert len(responses) == 2
+
+    def test_run_skips_blank_lines(self):
+        req = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "system/health"})
+        responses = self._run_with_lines(["", req, ""])
+        assert len(responses) == 1
+
+    def test_run_notification_produces_no_output(self):
+        notification = json.dumps({"jsonrpc": "2.0", "method": "system/health"})
+        responses = self._run_with_lines([notification])
+        assert responses == []


### PR DESCRIPTION
## Summary
- New `core/transport.py` with `StdioTransport` class
- JSON-RPC 2.0 over stdin/stdout — enables TUI, IDE, browser interfaces
- Methods: `goal/run`, `goal/add`, `goal/status`, `system/health`
- Full error handling per JSON-RPC 2.0 spec
- 36 tests

Closes #209

## Test plan
- [ ] 36 transport tests pass
- [ ] No regressions