### PR TITLE
feat: Phase 1 — ReAct Loop Engine + Graph Workflow Engine

### DIFF
--- a/core/graph_engine.py
+++ b/core/graph_engine.py
@@ -1,0 +1,554 @@
+"""
+Graph Workflow Engine — directed-graph execution engine for AURA workflows.
+
+Workflows are defined as configurations (YAML/JSON or programmatic API).
+Nodes are agents, tools, or LLM calls. Edges define data flow with
+optional conditions. Supports cyclic graphs with max-iteration guards
+and subgraph nesting.
+
+Usage (programmatic):
+    from core.graph_engine import StateGraph
+
+    def classify(state):
+        state["category"] = "bug" if "error" in state["text"] else "feature"
+        return state
+
+    def handle_bug(state):
+        state["result"] = "Filed bug report"
+        return state
+
+    graph = StateGraph(state_schema={"text": str, "category": str, "result": str})
+    graph.add_node("classify", classify)
+    graph.add_node("handle_bug", handle_bug)
+    graph.add_node("handle_feature", lambda s: {**s, "result": "Added to backlog"})
+    graph.set_entry_point("classify")
+    graph.add_conditional_edges("classify", lambda s: s["category"], {
+        "bug": "handle_bug",
+        "feature": "handle_feature",
+    })
+    workflow = graph.compile()
+    result = workflow.invoke({"text": "error in login"})
+
+Usage (YAML):
+    workflow = StateGraph.from_yaml("my_workflow.yaml")
+    compiled = workflow.compile()
+    result = compiled.invoke(initial_state)
+"""
+from __future__ import annotations
+
+import copy
+import json
+import time
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Literal, Optional, Set, Tuple, Type, Union
+
+from core.logging_utils import log_json
+
+# Sentinel for graph end
+END = "__end__"
+
+
+# ---------------------------------------------------------------------------
+# State management
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StateReducer:
+    """Defines how partial node outputs merge into shared state.
+
+    By default, node outputs are shallow-merged (dict.update).
+    A custom reducer_fn can implement append-style or deep-merge logic.
+    """
+    reducer_fn: Optional[Callable[[Dict[str, Any], Dict[str, Any]], Dict[str, Any]]] = None
+
+    def merge(self, current: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+        if self.reducer_fn:
+            return self.reducer_fn(current, update)
+        # Default: shallow merge
+        merged = dict(current)
+        merged.update(update)
+        return merged
+
+
+# ---------------------------------------------------------------------------
+# Graph definition types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class NodeDef:
+    """A node in the graph."""
+    name: str
+    fn: Callable[[Dict[str, Any]], Dict[str, Any]]
+    is_subgraph: bool = False
+
+
+@dataclass
+class EdgeDef:
+    """An unconditional edge."""
+    source: str
+    target: str
+
+
+@dataclass
+class ConditionalEdgeDef:
+    """A conditional edge with routing based on state."""
+    source: str
+    condition_fn: Callable[[Dict[str, Any]], str]
+    mapping: Dict[str, str]  # condition result → target node name
+
+
+# ---------------------------------------------------------------------------
+# Compiled graph
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ExecutionStep:
+    """One step in a graph execution trace."""
+    node: str
+    timestamp: str
+    input_state: Dict[str, Any]
+    output_state: Dict[str, Any]
+    duration_ms: float
+    iteration: int
+
+
+@dataclass
+class GraphResult:
+    """Result of a compiled graph execution."""
+    state: Dict[str, Any]
+    steps: List[ExecutionStep] = field(default_factory=list)
+    status: Literal["completed", "max_iterations", "error"] = "completed"
+    run_id: str = ""
+    total_duration_ms: float = 0.0
+
+
+class CompiledGraph:
+    """An executable workflow compiled from a StateGraph.
+
+    Executes nodes following edges (unconditional and conditional),
+    supports cycles with max-iteration guards, and nested subgraphs.
+    """
+
+    def __init__(
+        self,
+        nodes: Dict[str, NodeDef],
+        edges: List[EdgeDef],
+        conditional_edges: List[ConditionalEdgeDef],
+        entry_point: str,
+        state_schema: Optional[Dict[str, Any]],
+        reducer: StateReducer,
+        max_iterations: int,
+        graph_name: str = "",
+    ):
+        self._nodes = nodes
+        self._edges = edges
+        self._conditional_edges = conditional_edges
+        self._entry_point = entry_point
+        self._state_schema = state_schema
+        self._reducer = reducer
+        self._max_iterations = max_iterations
+        self._graph_name = graph_name
+
+        # Build adjacency for quick lookup
+        self._unconditional: Dict[str, List[str]] = {}
+        for e in edges:
+            self._unconditional.setdefault(e.source, []).append(e.target)
+
+        self._conditional: Dict[str, List[ConditionalEdgeDef]] = {}
+        for ce in conditional_edges:
+            self._conditional.setdefault(ce.source, []).append(ce)
+
+    def invoke(self, initial_state: Dict[str, Any]) -> GraphResult:
+        """Execute the graph starting from the entry point."""
+        run_id = uuid.uuid4().hex[:12]
+        start_time = time.monotonic()
+        state = dict(initial_state)
+        steps: List[ExecutionStep] = []
+        iteration = 0
+        current_node = self._entry_point
+
+        log_json("INFO", "graph_invoke_start", details={
+            "run_id": run_id, "graph": self._graph_name,
+            "entry": self._entry_point,
+        })
+
+        try:
+            while current_node != END and iteration < self._max_iterations:
+                iteration += 1
+                node_def = self._nodes.get(current_node)
+                if node_def is None:
+                    log_json("ERROR", "graph_unknown_node", details={
+                        "run_id": run_id, "node": current_node,
+                    })
+                    return GraphResult(
+                        state=state, steps=steps, status="error",
+                        run_id=run_id,
+                        total_duration_ms=(time.monotonic() - start_time) * 1000,
+                    )
+
+                # Execute node
+                input_snapshot = copy.deepcopy(state)
+                node_start = time.monotonic()
+                try:
+                    output = node_def.fn(copy.deepcopy(state))
+                except Exception as exc:
+                    log_json("WARN", "graph_node_error", details={
+                        "run_id": run_id, "node": current_node,
+                        "error": str(exc),
+                    })
+                    output = dict(state)
+                    output["__error__"] = str(exc)
+
+                node_ms = (time.monotonic() - node_start) * 1000
+
+                # Merge output into state
+                state = self._reducer.merge(state, output)
+
+                steps.append(ExecutionStep(
+                    node=current_node,
+                    timestamp=_now_iso(),
+                    input_state=input_snapshot,
+                    output_state=copy.deepcopy(state),
+                    duration_ms=node_ms,
+                    iteration=iteration,
+                ))
+
+                # Resolve next node
+                current_node = self._resolve_next(current_node, state)
+
+            status = "completed" if current_node == END else "max_iterations"
+            if status == "max_iterations":
+                log_json("WARN", "graph_max_iterations", details={
+                    "run_id": run_id, "iterations": iteration,
+                    "max": self._max_iterations,
+                })
+
+        except Exception:
+            status = "error"
+            log_json("ERROR", "graph_invoke_error", details={
+                "run_id": run_id, "error": traceback.format_exc(),
+            })
+
+        total_ms = (time.monotonic() - start_time) * 1000
+        log_json("INFO", "graph_invoke_end", details={
+            "run_id": run_id, "status": status,
+            "iterations": iteration, "duration_ms": total_ms,
+        })
+
+        return GraphResult(
+            state=state, steps=steps, status=status,
+            run_id=run_id, total_duration_ms=total_ms,
+        )
+
+    def _resolve_next(self, current: str, state: Dict[str, Any]) -> str:
+        """Determine the next node from edges."""
+        # Conditional edges take priority
+        cond_edges = self._conditional.get(current, [])
+        for ce in cond_edges:
+            try:
+                result = ce.condition_fn(state)
+                target = ce.mapping.get(result)
+                if target is not None:
+                    return target
+            except Exception:
+                log_json("WARN", "graph_condition_error", details={
+                    "source": current, "error": traceback.format_exc(),
+                })
+
+        # Fall back to unconditional edges
+        targets = self._unconditional.get(current, [])
+        if targets:
+            return targets[0]  # First unconditional edge
+
+        # No edges — implicit end
+        return END
+
+    def to_mermaid(self) -> str:
+        """Render the graph as a Mermaid diagram."""
+        lines = ["graph TD"]
+        for e in self._edges:
+            target_label = "END" if e.target == END else e.target
+            lines.append(f"    {e.source} --> {target_label}")
+        for ce in self._conditional_edges:
+            for label, target in ce.mapping.items():
+                target_label = "END" if target == END else target
+                lines.append(f"    {ce.source} -->|{label}| {target_label}")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# StateGraph builder
+# ---------------------------------------------------------------------------
+
+class StateGraph:
+    """Builder for constructing graph workflows.
+
+    Args:
+        state_schema: Optional dict mapping key names to types for documentation.
+        reducer: Custom state reducer (default: shallow merge).
+        max_iterations: Maximum graph-execution iterations (cycle guard).
+        name: Human-readable graph name.
+    """
+
+    def __init__(
+        self,
+        state_schema: Optional[Dict[str, Any]] = None,
+        reducer: Optional[StateReducer] = None,
+        max_iterations: int = 50,
+        name: str = "",
+    ):
+        self._state_schema = state_schema
+        self._reducer = reducer or StateReducer()
+        self._max_iterations = max_iterations
+        self._name = name
+        self._nodes: Dict[str, NodeDef] = {}
+        self._edges: List[EdgeDef] = []
+        self._conditional_edges: List[ConditionalEdgeDef] = []
+        self._entry_point: Optional[str] = None
+
+    def add_node(self, name: str, fn: Callable[[Dict[str, Any]], Dict[str, Any]]) -> "StateGraph":
+        """Register a node.
+
+        A node function receives the current state dict and returns a
+        (possibly partial) state dict that gets merged via the reducer.
+        """
+        if name in self._nodes:
+            raise ValueError(f"Node '{name}' already exists")
+        if name == END:
+            raise ValueError(f"'{END}' is reserved as the graph end sentinel")
+        self._nodes[name] = NodeDef(name=name, fn=fn)
+        return self
+
+    def add_edge(self, source: str, target: str) -> "StateGraph":
+        """Add an unconditional edge from *source* to *target*.
+
+        Use ``END`` (imported from this module) as *target* to mark a terminal edge.
+        """
+        self._validate_node_ref(source, is_source=True)
+        if target != END:
+            self._validate_node_ref(target, is_source=False)
+        self._edges.append(EdgeDef(source=source, target=target))
+        return self
+
+    def add_conditional_edges(
+        self,
+        source: str,
+        condition_fn: Callable[[Dict[str, Any]], str],
+        mapping: Dict[str, str],
+    ) -> "StateGraph":
+        """Add conditional edges from *source*, routed by *condition_fn*.
+
+        *condition_fn* receives the current state and returns a string key.
+        *mapping* maps those keys to target node names (or ``END``).
+        """
+        self._validate_node_ref(source, is_source=True)
+        for target in mapping.values():
+            if target != END:
+                self._validate_node_ref(target, is_source=False)
+        self._conditional_edges.append(
+            ConditionalEdgeDef(source=source, condition_fn=condition_fn, mapping=mapping)
+        )
+        return self
+
+    def set_entry_point(self, name: str) -> "StateGraph":
+        """Designate the start node."""
+        self._validate_node_ref(name, is_source=True)
+        self._entry_point = name
+        return self
+
+    def compile(self) -> CompiledGraph:
+        """Compile the graph into an executable ``CompiledGraph``."""
+        if self._entry_point is None:
+            raise ValueError("Entry point must be set before compiling (call set_entry_point)")
+        if not self._nodes:
+            raise ValueError("Graph must have at least one node")
+        return CompiledGraph(
+            nodes=dict(self._nodes),
+            edges=list(self._edges),
+            conditional_edges=list(self._conditional_edges),
+            entry_point=self._entry_point,
+            state_schema=self._state_schema,
+            reducer=self._reducer,
+            max_iterations=self._max_iterations,
+            graph_name=self._name,
+        )
+
+    # -- Subgraph support ---------------------------------------------------
+
+    def add_subgraph(self, name: str, subgraph: CompiledGraph) -> "StateGraph":
+        """Add a compiled graph as a node (subgraph nesting).
+
+        The subgraph's ``invoke`` method will be called with the current state.
+        """
+        if name in self._nodes:
+            raise ValueError(f"Node '{name}' already exists")
+
+        def _run_subgraph(state: Dict[str, Any]) -> Dict[str, Any]:
+            result = subgraph.invoke(state)
+            return result.state
+
+        self._nodes[name] = NodeDef(name=name, fn=_run_subgraph, is_subgraph=True)
+        return self
+
+    # -- YAML / JSON loading ------------------------------------------------
+
+    @classmethod
+    def from_yaml(cls, path: Union[str, Path], node_registry: Optional[Dict[str, Callable]] = None) -> "StateGraph":
+        """Load a graph definition from a YAML file.
+
+        The *node_registry* maps node function names (strings in YAML) to
+        actual callables.
+        """
+        import yaml
+        path = Path(path)
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return cls._from_dict(data, node_registry)
+
+    @classmethod
+    def from_json(cls, path: Union[str, Path], node_registry: Optional[Dict[str, Callable]] = None) -> "StateGraph":
+        """Load a graph definition from a JSON file."""
+        path = Path(path)
+        with open(path) as f:
+            data = json.load(f)
+        return cls._from_dict(data, node_registry)
+
+    @classmethod
+    def _from_dict(cls, data: Dict[str, Any], node_registry: Optional[Dict[str, Callable]] = None) -> "StateGraph":
+        """Build a StateGraph from a parsed YAML/JSON dict.
+
+        Expected schema:
+            name: str
+            max_iterations: int (optional, default 50)
+            state_schema: dict (optional)
+            nodes:
+              - name: str
+                function: str  (key in node_registry)
+            entry_point: str
+            edges:
+              - source: str
+                target: str
+            conditional_edges:
+              - source: str
+                condition: str  (key in node_registry)
+                mapping:
+                  key: target_node
+        """
+        registry = node_registry or {}
+        _validate_workflow_schema(data)
+
+        graph = cls(
+            state_schema=data.get("state_schema"),
+            max_iterations=data.get("max_iterations", 50),
+            name=data.get("name", ""),
+        )
+
+        # Nodes
+        for node_spec in data.get("nodes", []):
+            fn_name = node_spec["function"]
+            fn = registry.get(fn_name)
+            if fn is None:
+                raise ValueError(f"Node function '{fn_name}' not found in node_registry")
+            graph.add_node(node_spec["name"], fn)
+
+        # Entry point
+        graph.set_entry_point(data["entry_point"])
+
+        # Edges
+        for edge_spec in data.get("edges", []):
+            target = edge_spec["target"]
+            if target == "__end__":
+                target = END
+            graph.add_edge(edge_spec["source"], target)
+
+        # Conditional edges
+        for ce_spec in data.get("conditional_edges", []):
+            cond_name = ce_spec["condition"]
+            cond_fn = registry.get(cond_name)
+            if cond_fn is None:
+                raise ValueError(f"Condition function '{cond_name}' not found in node_registry")
+            mapping = {
+                k: (END if v == "__end__" else v)
+                for k, v in ce_spec["mapping"].items()
+            }
+            graph.add_conditional_edges(ce_spec["source"], cond_fn, mapping)
+
+        return graph
+
+    # -- Validation helpers -------------------------------------------------
+
+    def _validate_node_ref(self, name: str, is_source: bool) -> None:
+        """Raise if a referenced node doesn't exist."""
+        if name not in self._nodes:
+            role = "source" if is_source else "target"
+            raise ValueError(f"Unknown {role} node '{name}'. Add it with add_node() first.")
+
+    def get_graph(self) -> "StateGraph":
+        """Return self — convenience for chaining ``get_graph().to_mermaid()``."""
+        return self
+
+    def to_mermaid(self) -> str:
+        """Render the graph definition as a Mermaid diagram (before compilation)."""
+        compiled = self.compile()
+        return compiled.to_mermaid()
+
+
+# ---------------------------------------------------------------------------
+# Schema validation for YAML/JSON workflows
+# ---------------------------------------------------------------------------
+
+_REQUIRED_KEYS = {"nodes", "entry_point"}
+_ALLOWED_TOP_KEYS = {"name", "max_iterations", "state_schema", "nodes", "entry_point", "edges", "conditional_edges"}
+
+
+def _validate_workflow_schema(data: Dict[str, Any]) -> None:
+    """Validate a workflow definition dict. Raises ValueError on problems."""
+    if not isinstance(data, dict):
+        raise ValueError("Workflow definition must be a dict")
+    missing = _REQUIRED_KEYS - set(data.keys())
+    if missing:
+        raise ValueError(f"Missing required keys: {missing}")
+    unknown = set(data.keys()) - _ALLOWED_TOP_KEYS
+    if unknown:
+        raise ValueError(f"Unknown keys in workflow definition: {unknown}")
+    for node_spec in data.get("nodes", []):
+        if "name" not in node_spec or "function" not in node_spec:
+            raise ValueError(f"Each node must have 'name' and 'function': {node_spec}")
+
+
+# ---------------------------------------------------------------------------
+# ReAct-as-node adapter
+# ---------------------------------------------------------------------------
+
+def react_node(react_loop: Any, goal_key: str = "goal", answer_key: str = "answer") -> Callable:
+    """Wrap a ``ReActLoop`` so it can be used as a node in a StateGraph.
+
+    Args:
+        react_loop: A ``ReActLoop`` instance.
+        goal_key: State key containing the goal string.
+        answer_key: State key to write the answer into.
+
+    Returns:
+        A node function ``(state: dict) -> dict``.
+    """
+    def _node_fn(state: Dict[str, Any]) -> Dict[str, Any]:
+        goal = state.get(goal_key, "")
+        result = react_loop.run(goal)
+        return {
+            answer_key: result.answer,
+            "__react_status__": result.status,
+            "__react_trace__": result.trace.to_dict(),
+        }
+    return _node_fn
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/core/react_engine.py
+++ b/core/react_engine.py
@@ -1,0 +1,401 @@
+"""
+ReAct Loop Engine — interleaved Think-Act-Observe execution loop.
+
+The core agent runtime for AURA. Every subsequent capability hooks into
+this loop via the pre_think / post_act / post_observe hook system.
+
+Usage:
+    from core.react_engine import ReActLoop, Tool, ToolSchema
+
+    def search(query: str) -> str:
+        return f"Results for: {query}"
+
+    loop = ReActLoop(
+        llm=my_llm_provider,
+        tools=[Tool(name="search", description="Search the web",
+                    fn=search, schema=ToolSchema(parameters={"query": {"type": "string"}}))],
+        max_steps=10,
+    )
+    result = loop.run("Find the capital of France")
+"""
+from __future__ import annotations
+
+import time
+import traceback
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Literal, Optional, Protocol
+
+from core.logging_utils import log_json
+
+
+# ---------------------------------------------------------------------------
+# Tool schema & registration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ToolSchema:
+    """JSON-Schema-style parameter description for a tool."""
+    parameters: Dict[str, Any] = field(default_factory=dict)
+    required: List[str] = field(default_factory=list)
+
+    def validate(self, args: Dict[str, Any]) -> List[str]:
+        """Return a list of validation errors (empty = valid)."""
+        errors: List[str] = []
+        for key in self.required:
+            if key not in args:
+                errors.append(f"Missing required parameter: {key}")
+        for key, value in args.items():
+            if key in self.parameters:
+                param_spec = self.parameters[key]
+                expected_type = param_spec.get("type") if isinstance(param_spec, dict) else param_spec
+                if expected_type and not _type_matches(value, expected_type):
+                    errors.append(f"Parameter '{key}' expected type '{expected_type}', got '{type(value).__name__}'")
+        return errors
+
+
+def _type_matches(value: Any, type_str: str) -> bool:
+    """Check if a value roughly matches a JSON-Schema type string."""
+    mapping = {
+        "string": str,
+        "integer": int,
+        "number": (int, float),
+        "boolean": bool,
+        "array": list,
+        "object": dict,
+    }
+    expected = mapping.get(type_str)
+    if expected is None:
+        return True  # unknown type — pass through
+    return isinstance(value, expected)
+
+
+@dataclass
+class Tool:
+    """A tool that the ReAct agent can invoke."""
+    name: str
+    description: str
+    fn: Callable[..., Any]
+    schema: ToolSchema = field(default_factory=ToolSchema)
+
+
+# ---------------------------------------------------------------------------
+# Trace types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TraceStep:
+    """One step in the reasoning trace."""
+    step_number: int
+    phase: Literal["think", "act", "observe"]
+    timestamp: str
+    content: Any
+    duration_ms: float = 0.0
+
+
+@dataclass
+class ReActTrace:
+    """Complete execution trace for a ReAct run."""
+    run_id: str
+    goal: str
+    steps: List[TraceStep] = field(default_factory=list)
+    final_answer: Optional[str] = None
+    status: Literal["running", "completed", "max_steps", "aborted", "error"] = "running"
+    total_duration_ms: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "goal": self.goal,
+            "steps": [
+                {
+                    "step_number": s.step_number,
+                    "phase": s.phase,
+                    "timestamp": s.timestamp,
+                    "content": s.content,
+                    "duration_ms": s.duration_ms,
+                }
+                for s in self.steps
+            ],
+            "final_answer": self.final_answer,
+            "status": self.status,
+            "total_duration_ms": self.total_duration_ms,
+        }
+
+
+# ---------------------------------------------------------------------------
+# LLM Provider abstraction
+# ---------------------------------------------------------------------------
+
+class LLMProvider(Protocol):
+    """Pluggable interface for LLM backends.
+
+    Implementations must provide a ``think`` method that accepts the current
+    conversation context and returns a structured decision dict.
+    """
+
+    def think(
+        self,
+        goal: str,
+        tools: List[Dict[str, Any]],
+        history: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        """Return a decision dict with keys:
+        - "thought": str  — the reasoning text
+        - "action": str | None  — tool name, or None for final answer
+        - "action_input": dict | None  — tool arguments
+        - "final_answer": str | None  — set when the agent is done
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Hook system
+# ---------------------------------------------------------------------------
+
+HookFn = Callable[[Dict[str, Any]], None]
+
+
+@dataclass
+class HookRegistry:
+    """Manages pre_think / post_act / post_observe hooks."""
+    pre_think: List[HookFn] = field(default_factory=list)
+    post_act: List[HookFn] = field(default_factory=list)
+    post_observe: List[HookFn] = field(default_factory=list)
+
+    def fire(self, phase: str, payload: Dict[str, Any]) -> None:
+        hooks = getattr(self, phase, [])
+        for hook in hooks:
+            try:
+                hook(payload)
+            except Exception:
+                log_json("WARN", f"Hook error in {phase}", details={
+                    "error": traceback.format_exc(),
+                })
+
+
+# ---------------------------------------------------------------------------
+# ReAct Loop
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ReActResult:
+    """Result of a ReAct loop execution."""
+    answer: Optional[str]
+    trace: ReActTrace
+    status: str
+
+
+class ReActLoop:
+    """Core Think-Act-Observe execution loop.
+
+    Args:
+        llm: An LLM provider implementing the ``LLMProvider`` protocol.
+        tools: List of ``Tool`` objects the agent can call.
+        max_steps: Maximum think-act-observe iterations.
+        timeout_s: Wall-clock timeout in seconds (0 = no limit).
+        stop_condition: Optional callable that receives the trace and returns
+            True to stop early.
+        hooks: Optional pre-configured hook registry.
+    """
+
+    def __init__(
+        self,
+        llm: LLMProvider,
+        tools: Optional[List[Tool]] = None,
+        max_steps: int = 10,
+        timeout_s: float = 0,
+        stop_condition: Optional[Callable[[ReActTrace], bool]] = None,
+        hooks: Optional[HookRegistry] = None,
+    ):
+        self.llm = llm
+        self.max_steps = max_steps
+        self.timeout_s = timeout_s
+        self.stop_condition = stop_condition
+        self.hooks = hooks or HookRegistry()
+        self._tools: Dict[str, Tool] = {}
+        for tool in (tools or []):
+            self.register_tool(tool)
+
+    # -- Tool management ----------------------------------------------------
+
+    def register_tool(self, tool: Tool) -> None:
+        """Register a tool for the agent to use."""
+        if tool.name in self._tools:
+            raise ValueError(f"Tool '{tool.name}' already registered")
+        self._tools[tool.name] = tool
+
+    def _tool_specs(self) -> List[Dict[str, Any]]:
+        """Return tool descriptions for the LLM prompt."""
+        return [
+            {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.schema.parameters,
+                "required": t.schema.required,
+            }
+            for t in self._tools.values()
+        ]
+
+    # -- Execution ----------------------------------------------------------
+
+    def run(self, goal: str) -> ReActResult:
+        """Execute the ReAct loop for a given goal.
+
+        Returns a ``ReActResult`` with the final answer, trace, and status.
+        """
+        run_id = uuid.uuid4().hex[:12]
+        trace = ReActTrace(run_id=run_id, goal=goal)
+        start_time = time.monotonic()
+        step_num = 0
+
+        log_json("INFO", "react_loop_start", goal=goal, details={
+            "run_id": run_id,
+            "max_steps": self.max_steps,
+            "tools": list(self._tools.keys()),
+        })
+
+        history: List[Dict[str, Any]] = []
+
+        try:
+            while step_num < self.max_steps:
+                elapsed = (time.monotonic() - start_time) * 1000
+                if self.timeout_s > 0 and elapsed > self.timeout_s * 1000:
+                    trace.status = "aborted"
+                    log_json("WARN", "react_loop_timeout", goal=goal, details={
+                        "run_id": run_id, "elapsed_ms": elapsed,
+                    })
+                    break
+
+                step_num += 1
+
+                # --- THINK ---
+                self.hooks.fire("pre_think", {
+                    "run_id": run_id, "step": step_num, "goal": goal,
+                    "history": history,
+                })
+
+                think_start = time.monotonic()
+                decision = self.llm.think(
+                    goal=goal,
+                    tools=self._tool_specs(),
+                    history=history,
+                )
+                think_ms = (time.monotonic() - think_start) * 1000
+
+                thought = decision.get("thought", "")
+                trace.steps.append(TraceStep(
+                    step_number=step_num, phase="think",
+                    timestamp=_now_iso(), content=thought,
+                    duration_ms=think_ms,
+                ))
+                history.append({"role": "think", "content": thought})
+
+                # Check for final answer
+                final_answer = decision.get("final_answer")
+                if final_answer is not None:
+                    trace.final_answer = final_answer
+                    trace.status = "completed"
+                    log_json("INFO", "react_loop_final_answer", goal=goal, details={
+                        "run_id": run_id, "step": step_num, "answer": final_answer,
+                    })
+                    break
+
+                # --- ACT ---
+                action_name = decision.get("action")
+                action_input = decision.get("action_input", {})
+
+                if action_name is None:
+                    # No action and no final answer — treat as malformed; observe error
+                    observation = "Error: LLM returned neither an action nor a final answer."
+                else:
+                    observation = self._execute_tool(action_name, action_input)
+
+                trace.steps.append(TraceStep(
+                    step_number=step_num, phase="act",
+                    timestamp=_now_iso(),
+                    content={"action": action_name, "input": action_input},
+                ))
+                history.append({
+                    "role": "act",
+                    "content": {"action": action_name, "input": action_input},
+                })
+
+                self.hooks.fire("post_act", {
+                    "run_id": run_id, "step": step_num,
+                    "action": action_name, "input": action_input,
+                })
+
+                # --- OBSERVE ---
+                trace.steps.append(TraceStep(
+                    step_number=step_num, phase="observe",
+                    timestamp=_now_iso(), content=observation,
+                ))
+                history.append({"role": "observe", "content": observation})
+
+                self.hooks.fire("post_observe", {
+                    "run_id": run_id, "step": step_num,
+                    "observation": observation,
+                })
+
+                # Check stop condition
+                if self.stop_condition and self.stop_condition(trace):
+                    trace.status = "completed"
+                    break
+            else:
+                # Exhausted max_steps
+                trace.status = "max_steps"
+                log_json("WARN", "react_loop_max_steps", goal=goal, details={
+                    "run_id": run_id, "max_steps": self.max_steps,
+                })
+
+        except Exception:
+            trace.status = "error"
+            log_json("ERROR", "react_loop_error", goal=goal, details={
+                "run_id": run_id, "error": traceback.format_exc(),
+            })
+
+        trace.total_duration_ms = (time.monotonic() - start_time) * 1000
+
+        log_json("INFO", "react_loop_end", goal=goal, details={
+            "run_id": run_id, "status": trace.status,
+            "steps": step_num, "duration_ms": trace.total_duration_ms,
+        })
+
+        return ReActResult(
+            answer=trace.final_answer,
+            trace=trace,
+            status=trace.status,
+        )
+
+    def _execute_tool(self, name: str, args: Dict[str, Any]) -> str:
+        """Execute a tool by name, returning the result as a string observation.
+
+        Tool failures are captured as error observations, not exceptions.
+        """
+        tool = self._tools.get(name)
+        if tool is None:
+            return f"Error: Unknown tool '{name}'. Available tools: {list(self._tools.keys())}"
+
+        # Validate arguments
+        errors = tool.schema.validate(args)
+        if errors:
+            return f"Error: Invalid arguments for tool '{name}': {'; '.join(errors)}"
+
+        try:
+            result = tool.fn(**args)
+            return str(result)
+        except Exception as exc:
+            log_json("WARN", "tool_execution_error", details={
+                "tool": name, "error": str(exc),
+            })
+            return f"Error executing tool '{name}': {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _now_iso() -> str:
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/examples/phase1_demo.py
+++ b/examples/phase1_demo.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Phase 1 Demo — ReAct Engine + Graph Workflow Engine working together.
+
+Demonstrates:
+  1. A ReAct agent solving a multi-step math task using tools.
+  2. A graph workflow with conditional branching and a cycle.
+  3. The ReAct loop used as a node inside a graph workflow.
+
+Run from repo root:
+    python examples/phase1_demo.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+# Allow running from repo root
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+os.environ.setdefault("AURA_SKIP_CHDIR", "1")
+
+from core.react_engine import ReActLoop, Tool, ToolSchema, HookRegistry
+from core.graph_engine import StateGraph, END, react_node
+
+
+# ============================================================================
+# Demo 1: ReAct Agent solving a multi-step task
+# ============================================================================
+
+class DemoLLM:
+    """Scripted LLM that simulates multi-step reasoning with tools."""
+
+    def __init__(self):
+        self._step = 0
+
+    def think(self, goal, tools, history):
+        self._step += 1
+
+        # Check what observations we have so far
+        observations = [h["content"] for h in history if h["role"] == "observe"]
+
+        if self._step == 1:
+            return {
+                "thought": "I need to calculate 15 * 7 first.",
+                "action": "multiply",
+                "action_input": {"a": 15, "b": 7},
+            }
+        elif self._step == 2:
+            return {
+                "thought": f"15 * 7 = {observations[-1]}. Now I need to add 33.",
+                "action": "add",
+                "action_input": {"a": int(observations[-1]), "b": 33},
+            }
+        else:
+            return {
+                "thought": f"The final result is {observations[-1]}.",
+                "final_answer": observations[-1],
+            }
+
+
+def demo_react_agent():
+    """ReAct agent calculates (15 * 7) + 33 using tools."""
+    print("=" * 60)
+    print("DEMO 1: ReAct Agent — Multi-step Math Task")
+    print("=" * 60)
+    print("Goal: Calculate (15 * 7) + 33\n")
+
+    # Define tools
+    add_tool = Tool(
+        name="add", description="Add two integers",
+        fn=lambda a, b: a + b,
+        schema=ToolSchema(
+            parameters={"a": {"type": "integer"}, "b": {"type": "integer"}},
+            required=["a", "b"],
+        ),
+    )
+    multiply_tool = Tool(
+        name="multiply", description="Multiply two integers",
+        fn=lambda a, b: a * b,
+        schema=ToolSchema(
+            parameters={"a": {"type": "integer"}, "b": {"type": "integer"}},
+            required=["a", "b"],
+        ),
+    )
+
+    # Hook to observe the reasoning
+    def trace_hook(payload):
+        pass  # Hooks are called but we'll print from the trace instead
+
+    hooks = HookRegistry(pre_think=[trace_hook])
+
+    # Run the ReAct loop
+    loop = ReActLoop(llm=DemoLLM(), tools=[add_tool, multiply_tool], max_steps=10, hooks=hooks)
+    result = loop.run("Calculate (15 * 7) + 33")
+
+    # Print trace
+    for step in result.trace.steps:
+        print(f"  [{step.phase.upper():>7}] {step.content}")
+
+    print(f"\n  Final Answer: {result.answer}")
+    print(f"  Status: {result.status}")
+    print(f"  Steps: {len(result.trace.steps)}")
+    assert result.answer == "138", f"Expected 138, got {result.answer}"
+    print("  PASSED\n")
+
+
+# ============================================================================
+# Demo 2: Graph Workflow with conditional branching and a cycle
+# ============================================================================
+
+def demo_graph_workflow():
+    """Code review workflow: lint → test → (pass → deploy | fail → fix → re-test)."""
+    print("=" * 60)
+    print("DEMO 2: Graph Workflow — Code Review with Retry Cycle")
+    print("=" * 60)
+    print("Workflow: lint → test → (pass → deploy | fail → fix → re-test)\n")
+
+    def lint(state):
+        state["lint_passed"] = True
+        state["log"] = state.get("log", []) + ["lint: passed"]
+        return state
+
+    def run_tests(state):
+        attempts = state.get("test_attempts", 0) + 1
+        state["test_attempts"] = attempts
+        # Fail on first attempt, pass on retry
+        passed = attempts >= 2
+        state["tests_passed"] = passed
+        state["log"] = state.get("log", []) + [
+            f"test (attempt {attempts}): {'passed' if passed else 'failed'}"
+        ]
+        return state
+
+    def route_test_result(state):
+        return "pass" if state.get("tests_passed") else "fail"
+
+    def fix_code(state):
+        state["log"] = state.get("log", []) + ["fix: applied code fix"]
+        return state
+
+    def deploy(state):
+        state["deployed"] = True
+        state["log"] = state.get("log", []) + ["deploy: success"]
+        return state
+
+    graph = StateGraph(name="code_review", max_iterations=20)
+    graph.add_node("lint", lint)
+    graph.add_node("test", run_tests)
+    graph.add_node("fix", fix_code)
+    graph.add_node("deploy", deploy)
+    graph.set_entry_point("lint")
+    graph.add_edge("lint", "test")
+    graph.add_conditional_edges("test", route_test_result, {
+        "pass": "deploy",
+        "fail": "fix",
+    })
+    graph.add_edge("fix", "test")   # cycle: fix → re-test
+    graph.add_edge("deploy", END)
+
+    result = graph.compile().invoke({"code": "print('hello')"})
+
+    print("  Execution log:")
+    for entry in result.state.get("log", []):
+        print(f"    - {entry}")
+
+    print(f"\n  Deployed: {result.state.get('deployed')}")
+    print(f"  Test attempts: {result.state.get('test_attempts')}")
+    print(f"  Status: {result.status}")
+    print(f"  Iterations: {len(result.steps)}")
+
+    # Mermaid diagram
+    mermaid = graph.compile().to_mermaid()
+    print(f"\n  Mermaid diagram:\n")
+    for line in mermaid.split("\n"):
+        print(f"    {line}")
+
+    assert result.state["deployed"] is True
+    assert result.state["test_attempts"] == 2
+    print("\n  PASSED\n")
+
+
+# ============================================================================
+# Demo 3: ReAct agent as a node inside a Graph Workflow
+# ============================================================================
+
+def demo_react_in_graph():
+    """Graph: prepare_question → ReAct agent → format_answer."""
+    print("=" * 60)
+    print("DEMO 3: ReAct Agent as a Graph Node")
+    print("=" * 60)
+    print("Workflow: prepare → agent(ReAct) → format\n")
+
+    class QuestionLLM:
+        def think(self, goal, tools, history):
+            if not any(h["role"] == "observe" for h in history):
+                return {
+                    "thought": "I should look this up.",
+                    "action": "lookup",
+                    "action_input": {"topic": goal},
+                }
+            return {
+                "thought": "Found the answer.",
+                "final_answer": "42 (the answer to everything)",
+            }
+
+    lookup = Tool(
+        name="lookup", description="Look up a topic",
+        fn=lambda topic: f"The answer to '{topic}' is 42.",
+        schema=ToolSchema(parameters={"topic": {"type": "string"}}, required=["topic"]),
+    )
+    agent_loop = ReActLoop(llm=QuestionLLM(), tools=[lookup], max_steps=5)
+
+    graph = StateGraph(name="agent_workflow")
+    graph.add_node("prepare", lambda s: {**s, "goal": s.get("question", "unknown")})
+    graph.add_node("agent", react_node(agent_loop))
+    graph.add_node("format", lambda s: {**s, "output": f"Q: {s['goal']} A: {s['answer']}"})
+    graph.set_entry_point("prepare")
+    graph.add_edge("prepare", "agent")
+    graph.add_edge("agent", "format")
+    graph.add_edge("format", END)
+
+    result = graph.compile().invoke({"question": "What is the meaning of life?"})
+
+    print(f"  Question: {result.state['question']}")
+    print(f"  Agent answer: {result.state['answer']}")
+    print(f"  Formatted: {result.state['output']}")
+    print(f"  Status: {result.status}")
+
+    assert result.state["answer"] is not None
+    assert "42" in result.state["answer"]
+    print("\n  PASSED\n")
+
+
+# ============================================================================
+
+if __name__ == "__main__":
+    demo_react_agent()
+    demo_graph_workflow()
+    demo_react_in_graph()
+    print("=" * 60)
+    print("All demos passed!")
+    print("=" * 60)

--- a/examples/sample_workflow.yaml
+++ b/examples/sample_workflow.yaml
@@ -1,0 +1,50 @@
+# Sample graph workflow definition — YAML format
+# This workflow classifies incoming text and routes it to the appropriate handler.
+#
+# Load with:
+#   from core.graph_engine import StateGraph
+#   graph = StateGraph.from_yaml("examples/sample_workflow.yaml", node_registry={...})
+#   result = graph.compile().invoke({"text": "error in production"})
+
+name: issue_triage
+max_iterations: 20
+
+state_schema:
+  text: string
+  category: string
+  priority: string
+  result: string
+
+nodes:
+  - name: classify
+    function: classify_fn
+  - name: prioritize
+    function: prioritize_fn
+  - name: handle_bug
+    function: handle_bug_fn
+  - name: handle_feature
+    function: handle_feature_fn
+  - name: report
+    function: report_fn
+
+entry_point: classify
+
+edges:
+  - source: handle_bug
+    target: report
+  - source: handle_feature
+    target: report
+  - source: report
+    target: __end__
+
+conditional_edges:
+  - source: classify
+    condition: route_category_fn
+    mapping:
+      bug: prioritize
+      feature: handle_feature
+  - source: prioritize
+    condition: route_priority_fn
+    mapping:
+      high: handle_bug
+      low: handle_feature

--- a/tests/test_graph_engine.py
+++ b/tests/test_graph_engine.py
@@ -1,0 +1,562 @@
+"""Tests for core/graph_engine.py — Graph Workflow Engine."""
+import json
+import os
+import tempfile
+import pytest
+from unittest.mock import MagicMock
+
+os.environ.setdefault("AURA_SKIP_CHDIR", "1")
+
+from core.graph_engine import (
+    END,
+    StateReducer,
+    NodeDef,
+    EdgeDef,
+    ConditionalEdgeDef,
+    StateGraph,
+    CompiledGraph,
+    GraphResult,
+    ExecutionStep,
+    react_node,
+    _validate_workflow_schema,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — node functions
+# ---------------------------------------------------------------------------
+
+def classify_node(state):
+    text = state.get("text", "")
+    state["category"] = "bug" if "error" in text.lower() else "feature"
+    return state
+
+
+def handle_bug(state):
+    state["result"] = "Bug report filed"
+    return state
+
+
+def handle_feature(state):
+    state["result"] = "Feature added to backlog"
+    return state
+
+
+def increment_node(state):
+    state["count"] = state.get("count", 0) + 1
+    return state
+
+
+def check_done(state):
+    return "done" if state.get("count", 0) >= 3 else "continue"
+
+
+# ---------------------------------------------------------------------------
+# StateReducer
+# ---------------------------------------------------------------------------
+
+class TestStateReducer:
+    def test_default_shallow_merge(self):
+        reducer = StateReducer()
+        result = reducer.merge({"a": 1, "b": 2}, {"b": 3, "c": 4})
+        assert result == {"a": 1, "b": 3, "c": 4}
+
+    def test_custom_reducer(self):
+        def append_reducer(current, update):
+            merged = dict(current)
+            for k, v in update.items():
+                if k in merged and isinstance(merged[k], list):
+                    merged[k] = merged[k] + [v] if not isinstance(v, list) else merged[k] + v
+                else:
+                    merged[k] = v
+            return merged
+
+        reducer = StateReducer(reducer_fn=append_reducer)
+        result = reducer.merge({"items": [1, 2]}, {"items": 3})
+        assert result == {"items": [1, 2, 3]}
+
+
+# ---------------------------------------------------------------------------
+# StateGraph builder
+# ---------------------------------------------------------------------------
+
+class TestStateGraph:
+    def test_add_node(self):
+        g = StateGraph()
+        g.add_node("a", classify_node)
+        assert "a" in g._nodes
+
+    def test_add_node_duplicate_raises(self):
+        g = StateGraph()
+        g.add_node("a", classify_node)
+        with pytest.raises(ValueError, match="already exists"):
+            g.add_node("a", classify_node)
+
+    def test_add_node_end_reserved(self):
+        g = StateGraph()
+        with pytest.raises(ValueError, match="reserved"):
+            g.add_node(END, classify_node)
+
+    def test_add_edge(self):
+        g = StateGraph()
+        g.add_node("a", classify_node)
+        g.add_node("b", handle_bug)
+        g.add_edge("a", "b")
+        assert len(g._edges) == 1
+
+    def test_add_edge_to_end(self):
+        g = StateGraph()
+        g.add_node("a", classify_node)
+        g.add_edge("a", END)
+        assert g._edges[0].target == END
+
+    def test_add_edge_unknown_source_raises(self):
+        g = StateGraph()
+        g.add_node("b", handle_bug)
+        with pytest.raises(ValueError, match="Unknown source"):
+            g.add_edge("a", "b")
+
+    def test_add_edge_unknown_target_raises(self):
+        g = StateGraph()
+        g.add_node("a", classify_node)
+        with pytest.raises(ValueError, match="Unknown target"):
+            g.add_edge("a", "nonexistent")
+
+    def test_set_entry_point(self):
+        g = StateGraph()
+        g.add_node("start", classify_node)
+        g.set_entry_point("start")
+        assert g._entry_point == "start"
+
+    def test_set_entry_point_unknown_raises(self):
+        g = StateGraph()
+        with pytest.raises(ValueError, match="Unknown"):
+            g.set_entry_point("nonexistent")
+
+    def test_compile_no_entry_raises(self):
+        g = StateGraph()
+        g.add_node("a", classify_node)
+        with pytest.raises(ValueError, match="Entry point"):
+            g.compile()
+
+    def test_compile_no_nodes_raises(self):
+        g = StateGraph()
+        with pytest.raises(ValueError, match="at least one node"):
+            g._entry_point = "x"
+            g.compile()
+
+    def test_add_conditional_edges(self):
+        g = StateGraph()
+        g.add_node("classify", classify_node)
+        g.add_node("handle_bug", handle_bug)
+        g.add_node("handle_feature", handle_feature)
+        g.add_conditional_edges("classify", lambda s: s["category"], {
+            "bug": "handle_bug",
+            "feature": "handle_feature",
+        })
+        assert len(g._conditional_edges) == 1
+
+    def test_get_graph_returns_self(self):
+        g = StateGraph()
+        assert g.get_graph() is g
+
+    def test_chaining(self):
+        g = StateGraph()
+        result = (
+            g.add_node("a", classify_node)
+             .add_node("b", handle_bug)
+             .add_edge("a", "b")
+             .set_entry_point("a")
+        )
+        assert result is g
+
+
+# ---------------------------------------------------------------------------
+# CompiledGraph execution
+# ---------------------------------------------------------------------------
+
+class TestCompiledGraphExecution:
+    def test_linear_workflow(self):
+        """Simple A → B → END."""
+        g = StateGraph(name="linear")
+        g.add_node("classify", classify_node)
+        g.add_node("handle_bug", handle_bug)
+        g.set_entry_point("classify")
+        g.add_edge("classify", "handle_bug")
+        g.add_edge("handle_bug", END)
+
+        result = g.compile().invoke({"text": "error in login"})
+        assert result.status == "completed"
+        assert result.state["category"] == "bug"
+        assert result.state["result"] == "Bug report filed"
+        assert len(result.steps) == 2
+
+    def test_conditional_branching(self):
+        """Conditional routing: classify → bug|feature handler."""
+        g = StateGraph(name="conditional")
+        g.add_node("classify", classify_node)
+        g.add_node("handle_bug", handle_bug)
+        g.add_node("handle_feature", handle_feature)
+        g.set_entry_point("classify")
+        g.add_conditional_edges("classify", lambda s: s["category"], {
+            "bug": "handle_bug",
+            "feature": "handle_feature",
+        })
+        g.add_edge("handle_bug", END)
+        g.add_edge("handle_feature", END)
+
+        # Bug path
+        result = g.compile().invoke({"text": "error in login"})
+        assert result.state["result"] == "Bug report filed"
+
+        # Feature path
+        result = g.compile().invoke({"text": "add dark mode"})
+        assert result.state["result"] == "Feature added to backlog"
+
+    def test_cyclic_graph_with_guard(self):
+        """Loop: increment → check → (continue → increment | done → END)."""
+        g = StateGraph(name="cyclic", max_iterations=20)
+        g.add_node("increment", increment_node)
+        g.set_entry_point("increment")
+        g.add_conditional_edges("increment", check_done, {
+            "continue": "increment",
+            "done": END,
+        })
+
+        result = g.compile().invoke({"count": 0})
+        assert result.status == "completed"
+        assert result.state["count"] == 3
+
+    def test_max_iterations_guard(self):
+        """Infinite loop stopped by max_iterations."""
+        def always_loop(state):
+            state["n"] = state.get("n", 0) + 1
+            return state
+
+        g = StateGraph(max_iterations=5)
+        g.add_node("loop", always_loop)
+        g.set_entry_point("loop")
+        g.add_edge("loop", "loop")  # infinite cycle
+
+        result = g.compile().invoke({})
+        assert result.status == "max_iterations"
+        assert result.state["n"] == 5
+
+    def test_node_error_captured(self):
+        """Node that raises exception — error captured in state."""
+        def bad_node(state):
+            raise RuntimeError("boom")
+
+        g = StateGraph()
+        g.add_node("bad", bad_node)
+        g.set_entry_point("bad")
+        g.add_edge("bad", END)
+
+        result = g.compile().invoke({})
+        assert result.status == "completed"
+        assert "__error__" in result.state
+        assert "boom" in result.state["__error__"]
+
+    def test_unknown_node_in_edge(self):
+        """Reference to unknown node during execution."""
+        g = StateGraph()
+        g.add_node("start", lambda s: s)
+        g.set_entry_point("start")
+        # Manually add edge to nonexistent node
+        compiled = g.compile()
+        compiled._unconditional["start"] = ["nonexistent"]
+
+        result = compiled.invoke({})
+        assert result.status == "error"
+
+    def test_implicit_end(self):
+        """Node with no outgoing edges → implicit END."""
+        g = StateGraph()
+        g.add_node("only", lambda s: {**s, "done": True})
+        g.set_entry_point("only")
+
+        result = g.compile().invoke({})
+        assert result.status == "completed"
+        assert result.state["done"] is True
+
+    def test_execution_trace(self):
+        """Verify execution steps are recorded."""
+        g = StateGraph()
+        g.add_node("a", lambda s: {**s, "a": True})
+        g.add_node("b", lambda s: {**s, "b": True})
+        g.set_entry_point("a")
+        g.add_edge("a", "b")
+        g.add_edge("b", END)
+
+        result = g.compile().invoke({})
+        assert len(result.steps) == 2
+        assert result.steps[0].node == "a"
+        assert result.steps[1].node == "b"
+        assert result.steps[0].duration_ms >= 0
+        assert result.run_id != ""
+
+    def test_state_isolation(self):
+        """Node receives a copy of state, not the shared mutable state."""
+        received_states = []
+
+        def capturing_node(state):
+            received_states.append(state)
+            state["captured"] = True
+            return state
+
+        g = StateGraph()
+        g.add_node("cap", capturing_node)
+        g.set_entry_point("cap")
+        g.add_edge("cap", END)
+
+        initial = {"x": 1}
+        result = g.compile().invoke(initial)
+        # The initial state should not be mutated
+        assert "captured" not in initial
+
+
+# ---------------------------------------------------------------------------
+# Subgraph nesting
+# ---------------------------------------------------------------------------
+
+class TestSubgraph:
+    def test_subgraph_as_node(self):
+        """A compiled graph used as a node in an outer graph."""
+        # Inner graph: increment twice
+        inner = StateGraph(name="inner")
+        inner.add_node("inc1", increment_node)
+        inner.add_node("inc2", increment_node)
+        inner.set_entry_point("inc1")
+        inner.add_edge("inc1", "inc2")
+        inner.add_edge("inc2", END)
+        compiled_inner = inner.compile()
+
+        # Outer graph: setup → inner → finalize
+        outer = StateGraph(name="outer")
+        outer.add_node("setup", lambda s: {**s, "count": 0})
+        outer.add_subgraph("inner", compiled_inner)
+        outer.add_node("finalize", lambda s: {**s, "final": True})
+        outer.set_entry_point("setup")
+        outer.add_edge("setup", "inner")
+        outer.add_edge("inner", "finalize")
+        outer.add_edge("finalize", END)
+
+        result = outer.compile().invoke({})
+        assert result.state["count"] == 2
+        assert result.state["final"] is True
+
+
+# ---------------------------------------------------------------------------
+# Mermaid visualization
+# ---------------------------------------------------------------------------
+
+class TestMermaid:
+    def test_mermaid_output(self):
+        g = StateGraph()
+        g.add_node("a", lambda s: s)
+        g.add_node("b", lambda s: s)
+        g.add_node("c", lambda s: s)
+        g.set_entry_point("a")
+        g.add_edge("a", "b")
+        g.add_conditional_edges("b", lambda s: "yes", {"yes": "c", "no": END})
+        g.add_edge("c", END)
+
+        mermaid = g.compile().to_mermaid()
+        assert "graph TD" in mermaid
+        assert "a --> b" in mermaid
+        assert "b -->|yes| c" in mermaid
+        assert "b -->|no| END" in mermaid
+        assert "c --> END" in mermaid
+
+
+# ---------------------------------------------------------------------------
+# YAML/JSON loading
+# ---------------------------------------------------------------------------
+
+class TestYAMLLoading:
+    def test_from_json(self):
+        """Load and execute a graph from a JSON definition."""
+        registry = {
+            "classify_fn": classify_node,
+            "handle_bug_fn": handle_bug,
+            "handle_feature_fn": handle_feature,
+            "route_fn": lambda s: s["category"],
+        }
+        definition = {
+            "name": "test_workflow",
+            "nodes": [
+                {"name": "classify", "function": "classify_fn"},
+                {"name": "handle_bug", "function": "handle_bug_fn"},
+                {"name": "handle_feature", "function": "handle_feature_fn"},
+            ],
+            "entry_point": "classify",
+            "conditional_edges": [
+                {
+                    "source": "classify",
+                    "condition": "route_fn",
+                    "mapping": {"bug": "handle_bug", "feature": "handle_feature"},
+                },
+            ],
+            "edges": [
+                {"source": "handle_bug", "target": "__end__"},
+                {"source": "handle_feature", "target": "__end__"},
+            ],
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(definition, f)
+            f.flush()
+            graph = StateGraph.from_json(f.name, node_registry=registry)
+
+        result = graph.compile().invoke({"text": "error found"})
+        assert result.state["result"] == "Bug report filed"
+        os.unlink(f.name)
+
+    def test_from_json_missing_function_raises(self):
+        definition = {
+            "nodes": [{"name": "a", "function": "missing_fn"}],
+            "entry_point": "a",
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(definition, f)
+            f.flush()
+            with pytest.raises(ValueError, match="not found in node_registry"):
+                StateGraph.from_json(f.name, node_registry={})
+        os.unlink(f.name)
+
+
+class TestSchemaValidation:
+    def test_valid_schema(self):
+        data = {
+            "nodes": [{"name": "a", "function": "fn"}],
+            "entry_point": "a",
+        }
+        _validate_workflow_schema(data)  # should not raise
+
+    def test_missing_required_keys(self):
+        with pytest.raises(ValueError, match="Missing required"):
+            _validate_workflow_schema({"name": "test"})
+
+    def test_unknown_keys(self):
+        with pytest.raises(ValueError, match="Unknown keys"):
+            _validate_workflow_schema({
+                "nodes": [{"name": "a", "function": "fn"}],
+                "entry_point": "a",
+                "bogus_key": True,
+            })
+
+    def test_invalid_node_spec(self):
+        with pytest.raises(ValueError, match="name.*function"):
+            _validate_workflow_schema({
+                "nodes": [{"description": "missing name and function"}],
+                "entry_point": "a",
+            })
+
+    def test_not_a_dict(self):
+        with pytest.raises(ValueError, match="must be a dict"):
+            _validate_workflow_schema("not a dict")
+
+
+# ---------------------------------------------------------------------------
+# react_node adapter
+# ---------------------------------------------------------------------------
+
+class TestReactNode:
+    def test_react_node_adapter(self):
+        """Wrap a ReActLoop as a graph node."""
+        # Mock the ReActLoop
+        mock_loop = MagicMock()
+        mock_result = MagicMock()
+        mock_result.answer = "42"
+        mock_result.status = "completed"
+        mock_result.trace.to_dict.return_value = {"steps": []}
+        mock_loop.run.return_value = mock_result
+
+        node_fn = react_node(mock_loop, goal_key="question", answer_key="answer")
+        output = node_fn({"question": "What is 6*7?"})
+
+        mock_loop.run.assert_called_once_with("What is 6*7?")
+        assert output["answer"] == "42"
+        assert output["__react_status__"] == "completed"
+
+    def test_react_node_in_graph(self):
+        """Use a react_node inside a StateGraph."""
+        mock_loop = MagicMock()
+        mock_result = MagicMock()
+        mock_result.answer = "Paris"
+        mock_result.status = "completed"
+        mock_result.trace.to_dict.return_value = {"steps": []}
+        mock_loop.run.return_value = mock_result
+
+        g = StateGraph()
+        g.add_node("setup", lambda s: {**s, "goal": "Capital of France?"})
+        g.add_node("agent", react_node(mock_loop))
+        g.add_node("format", lambda s: {**s, "formatted": f"Answer: {s.get('answer')}"})
+        g.set_entry_point("setup")
+        g.add_edge("setup", "agent")
+        g.add_edge("agent", "format")
+        g.add_edge("format", END)
+
+        result = g.compile().invoke({})
+        assert result.state["answer"] == "Paris"
+        assert result.state["formatted"] == "Answer: Paris"
+        assert result.status == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Five+ node workflow (acceptance criteria)
+# ---------------------------------------------------------------------------
+
+class TestFiveNodeWorkflow:
+    def test_five_node_conditional_workflow(self):
+        """5+ node workflow with conditional branching."""
+        def ingest(state):
+            state["ingested"] = True
+            return state
+
+        def analyze(state):
+            state["severity"] = "high" if "critical" in state.get("text", "") else "low"
+            return state
+
+        def route_severity(state):
+            return state["severity"]
+
+        def handle_high(state):
+            state["action"] = "page oncall"
+            return state
+
+        def handle_low(state):
+            state["action"] = "add to backlog"
+            return state
+
+        def report(state):
+            state["report"] = f"Action taken: {state['action']}"
+            return state
+
+        g = StateGraph(name="incident_response")
+        g.add_node("ingest", ingest)
+        g.add_node("analyze", analyze)
+        g.add_node("handle_high", handle_high)
+        g.add_node("handle_low", handle_low)
+        g.add_node("report", report)
+        g.set_entry_point("ingest")
+        g.add_edge("ingest", "analyze")
+        g.add_conditional_edges("analyze", route_severity, {
+            "high": "handle_high",
+            "low": "handle_low",
+        })
+        g.add_edge("handle_high", "report")
+        g.add_edge("handle_low", "report")
+        g.add_edge("report", END)
+
+        # High severity
+        r = g.compile().invoke({"text": "critical error in prod"})
+        assert r.state["action"] == "page oncall"
+        assert r.state["report"] == "Action taken: page oncall"
+        assert r.status == "completed"
+        assert len(r.steps) == 4  # ingest → analyze → handle_high → report
+
+        # Low severity
+        r = g.compile().invoke({"text": "minor UI tweak"})
+        assert r.state["action"] == "add to backlog"
+        assert len(r.steps) == 4

--- a/tests/test_react_engine.py
+++ b/tests/test_react_engine.py
@@ -1,0 +1,383 @@
+"""Tests for core/react_engine.py — ReAct Loop Engine."""
+import os
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+os.environ.setdefault("AURA_SKIP_CHDIR", "1")
+
+from core.react_engine import (
+    Tool,
+    ToolSchema,
+    TraceStep,
+    ReActTrace,
+    ReActLoop,
+    ReActResult,
+    HookRegistry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeLLM:
+    """Deterministic LLM for testing.
+
+    Accepts a list of decision dicts. Returns them in order on each
+    ``think`` call. If the list is exhausted, returns a final answer.
+    """
+
+    def __init__(self, decisions: list):
+        self._decisions = list(decisions)
+        self._call_count = 0
+
+    def think(self, goal, tools, history):
+        if self._call_count < len(self._decisions):
+            d = self._decisions[self._call_count]
+            self._call_count += 1
+            return d
+        return {"thought": "Done.", "final_answer": "fallback answer"}
+
+
+def _add_tool(a: int, b: int) -> int:
+    return a + b
+
+
+def _search_tool(query: str) -> str:
+    return f"Results for: {query}"
+
+
+def _failing_tool(x: str) -> str:
+    raise RuntimeError("intentional failure")
+
+
+# ---------------------------------------------------------------------------
+# ToolSchema
+# ---------------------------------------------------------------------------
+
+class TestToolSchema:
+    def test_validate_ok(self):
+        schema = ToolSchema(
+            parameters={"query": {"type": "string"}},
+            required=["query"],
+        )
+        assert schema.validate({"query": "hello"}) == []
+
+    def test_validate_missing_required(self):
+        schema = ToolSchema(
+            parameters={"query": {"type": "string"}},
+            required=["query"],
+        )
+        errors = schema.validate({})
+        assert len(errors) == 1
+        assert "Missing required" in errors[0]
+
+    def test_validate_wrong_type(self):
+        schema = ToolSchema(
+            parameters={"count": {"type": "integer"}},
+            required=[],
+        )
+        errors = schema.validate({"count": "not_a_number"})
+        assert len(errors) == 1
+        assert "expected type" in errors[0]
+
+    def test_validate_unknown_type_passes(self):
+        schema = ToolSchema(
+            parameters={"x": {"type": "custom_type"}},
+        )
+        assert schema.validate({"x": "anything"}) == []
+
+    def test_validate_empty_schema(self):
+        schema = ToolSchema()
+        assert schema.validate({"anything": 42}) == []
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+class TestTool:
+    def test_creation(self):
+        tool = Tool(name="add", description="Add two numbers", fn=_add_tool)
+        assert tool.name == "add"
+        assert tool.description == "Add two numbers"
+
+    def test_tool_with_schema(self):
+        schema = ToolSchema(
+            parameters={"a": {"type": "integer"}, "b": {"type": "integer"}},
+            required=["a", "b"],
+        )
+        tool = Tool(name="add", description="Add", fn=_add_tool, schema=schema)
+        assert tool.schema.required == ["a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# HookRegistry
+# ---------------------------------------------------------------------------
+
+class TestHookRegistry:
+    def test_fire_hooks(self):
+        record = []
+        hooks = HookRegistry(
+            pre_think=[lambda p: record.append(("pre_think", p))],
+            post_act=[lambda p: record.append(("post_act", p))],
+            post_observe=[lambda p: record.append(("post_observe", p))],
+        )
+        hooks.fire("pre_think", {"step": 1})
+        hooks.fire("post_act", {"action": "search"})
+        hooks.fire("post_observe", {"obs": "result"})
+        assert len(record) == 3
+        assert record[0][0] == "pre_think"
+        assert record[1][0] == "post_act"
+        assert record[2][0] == "post_observe"
+
+    def test_hook_error_does_not_crash(self):
+        def bad_hook(p):
+            raise ValueError("hook error")
+
+        hooks = HookRegistry(pre_think=[bad_hook])
+        # Should not raise
+        hooks.fire("pre_think", {"step": 1})
+
+    def test_unknown_phase(self):
+        hooks = HookRegistry()
+        # Should not raise for unknown phase
+        hooks.fire("unknown_phase", {})
+
+
+# ---------------------------------------------------------------------------
+# ReActTrace
+# ---------------------------------------------------------------------------
+
+class TestReActTrace:
+    def test_to_dict(self):
+        trace = ReActTrace(run_id="abc123", goal="test goal")
+        trace.steps.append(TraceStep(
+            step_number=1, phase="think",
+            timestamp="2026-01-01T00:00:00Z",
+            content="thinking...",
+            duration_ms=10.0,
+        ))
+        trace.final_answer = "42"
+        trace.status = "completed"
+        d = trace.to_dict()
+        assert d["run_id"] == "abc123"
+        assert d["goal"] == "test goal"
+        assert len(d["steps"]) == 1
+        assert d["steps"][0]["phase"] == "think"
+        assert d["final_answer"] == "42"
+        assert d["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# ReActLoop
+# ---------------------------------------------------------------------------
+
+class TestReActLoop:
+    def test_simple_final_answer(self):
+        """LLM immediately returns a final answer."""
+        llm = FakeLLM([
+            {"thought": "I know this.", "final_answer": "Paris"},
+        ])
+        loop = ReActLoop(llm=llm, tools=[])
+        result = loop.run("What is the capital of France?")
+        assert result.answer == "Paris"
+        assert result.status == "completed"
+        assert len(result.trace.steps) == 1  # one think step
+
+    def test_tool_use_then_answer(self):
+        """Agent calls a tool, observes result, then answers."""
+        llm = FakeLLM([
+            {
+                "thought": "I should search.",
+                "action": "search",
+                "action_input": {"query": "capital of France"},
+            },
+            {
+                "thought": "I found it.",
+                "final_answer": "Paris",
+            },
+        ])
+        search = Tool(
+            name="search", description="Search",
+            fn=_search_tool,
+            schema=ToolSchema(parameters={"query": {"type": "string"}}, required=["query"]),
+        )
+        loop = ReActLoop(llm=llm, tools=[search])
+        result = loop.run("capital of France")
+
+        assert result.answer == "Paris"
+        assert result.status == "completed"
+        # Step 1: think + act + observe. Step 2: think (final answer)
+        phases = [s.phase for s in result.trace.steps]
+        assert phases == ["think", "act", "observe", "think"]
+
+    def test_unknown_tool(self):
+        """Agent calls a tool that doesn't exist — gets error observation."""
+        llm = FakeLLM([
+            {
+                "thought": "Try a tool.",
+                "action": "nonexistent",
+                "action_input": {},
+            },
+            {"thought": "Got error, done.", "final_answer": "error handled"},
+        ])
+        loop = ReActLoop(llm=llm, tools=[])
+        result = loop.run("test")
+        # The observation should contain an error about unknown tool
+        obs_steps = [s for s in result.trace.steps if s.phase == "observe"]
+        assert len(obs_steps) == 1
+        assert "Unknown tool" in obs_steps[0].content
+
+    def test_tool_execution_failure(self):
+        """Tool raises an exception — captured as error observation."""
+        llm = FakeLLM([
+            {
+                "thought": "Try failing tool.",
+                "action": "fail",
+                "action_input": {"x": "data"},
+            },
+            {"thought": "Handled error.", "final_answer": "recovered"},
+        ])
+        fail_tool = Tool(
+            name="fail", description="Fails",
+            fn=_failing_tool,
+            schema=ToolSchema(parameters={"x": {"type": "string"}}),
+        )
+        loop = ReActLoop(llm=llm, tools=[fail_tool])
+        result = loop.run("test")
+        assert result.answer == "recovered"
+        obs_steps = [s for s in result.trace.steps if s.phase == "observe"]
+        assert "Error executing tool" in obs_steps[0].content
+
+    def test_max_steps_reached(self):
+        """Loop hits max_steps without final answer."""
+        # LLM always returns an action
+        decisions = [
+            {
+                "thought": f"Step {i}",
+                "action": "search",
+                "action_input": {"query": "loop"},
+            }
+            for i in range(20)
+        ]
+        llm = FakeLLM(decisions)
+        search = Tool(name="search", description="Search", fn=_search_tool,
+                       schema=ToolSchema(parameters={"query": {"type": "string"}}))
+        loop = ReActLoop(llm=llm, tools=[search], max_steps=3)
+        result = loop.run("test")
+        assert result.status == "max_steps"
+        assert result.answer is None
+
+    def test_timeout(self):
+        """Loop aborts on timeout."""
+        import time
+
+        class SlowLLM:
+            def think(self, goal, tools, history):
+                time.sleep(0.05)
+                return {"thought": "slow", "action": "search", "action_input": {"query": "x"}}
+
+        search = Tool(name="search", description="Search", fn=_search_tool,
+                       schema=ToolSchema(parameters={"query": {"type": "string"}}))
+        loop = ReActLoop(llm=SlowLLM(), tools=[search], max_steps=100, timeout_s=0.08)
+        result = loop.run("test")
+        assert result.status in ("aborted", "max_steps")
+
+    def test_register_tool_duplicate_raises(self):
+        llm = FakeLLM([])
+        tool = Tool(name="search", description="Search", fn=_search_tool)
+        loop = ReActLoop(llm=llm, tools=[tool])
+        with pytest.raises(ValueError, match="already registered"):
+            loop.register_tool(Tool(name="search", description="Dup", fn=_search_tool))
+
+    def test_hooks_called_during_execution(self):
+        """Verify hooks are called at correct phases."""
+        record = []
+        hooks = HookRegistry(
+            pre_think=[lambda p: record.append("pre_think")],
+            post_act=[lambda p: record.append("post_act")],
+            post_observe=[lambda p: record.append("post_observe")],
+        )
+        llm = FakeLLM([
+            {
+                "thought": "Use tool.",
+                "action": "search",
+                "action_input": {"query": "test"},
+            },
+            {"thought": "Done.", "final_answer": "result"},
+        ])
+        search = Tool(name="search", description="Search", fn=_search_tool,
+                       schema=ToolSchema(parameters={"query": {"type": "string"}}))
+        loop = ReActLoop(llm=llm, tools=[search], hooks=hooks)
+        result = loop.run("test")
+
+        assert result.status == "completed"
+        assert "pre_think" in record
+        assert "post_act" in record
+        assert "post_observe" in record
+
+    def test_stop_condition(self):
+        """Custom stop condition halts the loop."""
+        llm = FakeLLM([
+            {
+                "thought": "Step 1",
+                "action": "search",
+                "action_input": {"query": "stop"},
+            },
+        ] * 10)
+        search = Tool(name="search", description="Search", fn=_search_tool,
+                       schema=ToolSchema(parameters={"query": {"type": "string"}}))
+
+        def stop_after_2(trace):
+            return len([s for s in trace.steps if s.phase == "think"]) >= 2
+
+        loop = ReActLoop(llm=llm, tools=[search], max_steps=10, stop_condition=stop_after_2)
+        result = loop.run("test")
+        assert result.status == "completed"
+        think_steps = [s for s in result.trace.steps if s.phase == "think"]
+        assert len(think_steps) == 2
+
+    def test_schema_validation_error(self):
+        """Tool with invalid arguments gets validation error observation."""
+        llm = FakeLLM([
+            {
+                "thought": "Add numbers.",
+                "action": "add",
+                "action_input": {"a": "not_int", "b": 2},
+            },
+            {"thought": "Done.", "final_answer": "handled"},
+        ])
+        schema = ToolSchema(
+            parameters={"a": {"type": "integer"}, "b": {"type": "integer"}},
+            required=["a", "b"],
+        )
+        add_tool = Tool(name="add", description="Add", fn=_add_tool, schema=schema)
+        loop = ReActLoop(llm=llm, tools=[add_tool])
+        result = loop.run("test")
+        obs_steps = [s for s in result.trace.steps if s.phase == "observe"]
+        assert "Invalid arguments" in obs_steps[0].content
+
+    def test_no_action_no_final_answer(self):
+        """LLM returns neither action nor final_answer — treated as error."""
+        llm = FakeLLM([
+            {"thought": "I'm confused."},
+            {"thought": "Now I know.", "final_answer": "ok"},
+        ])
+        loop = ReActLoop(llm=llm, tools=[])
+        result = loop.run("test")
+        assert result.answer == "ok"
+        obs_steps = [s for s in result.trace.steps if s.phase == "observe"]
+        assert "neither an action nor a final answer" in obs_steps[0].content
+
+    def test_trace_run_id(self):
+        llm = FakeLLM([{"thought": "Done.", "final_answer": "yes"}])
+        loop = ReActLoop(llm=llm)
+        result = loop.run("test")
+        assert len(result.trace.run_id) == 12
+
+    def test_trace_total_duration(self):
+        llm = FakeLLM([{"thought": "Done.", "final_answer": "yes"}])
+        loop = ReActLoop(llm=llm)
+        result = loop.run("test")
+        assert result.trace.total_duration_ms > 0


### PR DESCRIPTION
## Summary

Implements the two foundational execution engines for AURA's agent runtime, as specified in Issues #431 and #432.

### ReAct Loop Engine (`core/react_engine.py`) — Issue #431
- **Core think-act-observe execution loop** with configurable max steps, timeout, and custom stop conditions
- **Tool Registration API** with JSON-Schema parameter validation — tools are callable by name with typed arguments
- **Hook system** (`pre_think`, `post_act`, `post_observe`) for Layer 2+ integration — external modules can inject memory, monitoring, and learning logic at each step
- **LLM Provider abstraction** via Python Protocol — pluggable interface supporting any backend (OpenAI, Anthropic, local models)
- **Structured trace logging** — full reasoning trace preserved with timestamps for debugging/replay
- **Error handling** — tool execution failures are captured as observations, enabling the agent to retry or adapt

### Graph Workflow Engine (`core/graph_engine.py`) — Issue #432
- **StateGraph builder API**: `add_node()`, `add_edge()`, `add_conditional_edges()`, `set_entry_point()`, `compile()`
- **Typed state management** with configurable reducers (shallow merge default, custom merge logic supported)
- **Cyclic graph support** with max-iteration guards to prevent infinite loops
- **Conditional edge routing** based on runtime state values
- **Subgraph nesting** — a node can be another compiled graph via `add_subgraph()`
- **YAML/JSON workflow definition** with schema validation via `from_yaml()` / `from_json()`
- **Mermaid graph visualization** via `to_mermaid()` for debugging

### Integration
- **`react_node()` adapter** wires a `ReActLoop` as a node in a `StateGraph`, enabling complex workflows where some nodes are full ReAct agents

### Files Added
| File | Description |
|------|-------------|
| `core/react_engine.py` | ReAct Loop Engine implementation |
| `core/graph_engine.py` | Graph Workflow Engine implementation |
| `tests/test_react_engine.py` | 24 tests for ReAct engine |
| `tests/test_graph_engine.py` | 37 tests for Graph engine |
| `examples/phase1_demo.py` | Working demo: ReAct agent, graph workflow with cycle, ReAct-in-graph |
| `examples/sample_workflow.yaml` | Sample YAML workflow definition |

## Test plan
- [x] All 61 new tests pass (`pytest tests/test_react_engine.py tests/test_graph_engine.py`)
- [x] Demo runs end-to-end (`python examples/phase1_demo.py`) — all 3 demos pass
- [x] ReAct agent solves multi-step task using registered tools
- [x] Graph workflow executes with conditional branching (bug vs feature path)
- [x] Cyclic graph (test → fail → fix → re-test) terminates correctly
- [x] Max-iteration guard prevents infinite loops
- [x] ReAct loop used as a node inside a graph workflow
- [x] YAML/JSON workflow loading with schema validation
- [x] Mermaid diagram generation

Closes #431, Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)