### PR TITLE
test: add syrupy golden file snapshot tests for DPoP and CredentialStore output (Phase 2c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     - name: Test with pytest + coverage
       run: |
         pytest -q --maxfail=3 --cov=aura_cli --cov=core --cov=agents --cov=memory --cov-report=xml --cov-report=term-missing
+    - name: Run golden file tests
+      run: pytest tests/security/test_golden_*.py -v --snapshot-warn-unused
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,18 @@ Example: `feat: add retry logic to agent orchestrator`
 - Add tests for any new functionality
 - Ensure all existing tests pass before submitting a PR
 
+### Updating Golden File Snapshots
+
+If you intentionally change CLI output, DPoP proof structure, or CredentialStore
+messages, update the snapshots:
+
+```bash
+pytest tests/security/test_golden_*.py --snapshot-update
+```
+
+Review the diff in `tests/security/__snapshots__/` carefully before committing —
+unexpected snapshot changes indicate a regression.
+
 ## Submitting a Pull Request
 
 1. Push your branch to your fork

--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -1,0 +1,1 @@
+"""AURA security — credential management, DPoP proof generation, and secure HTTP."""

--- a/core/security/credential_store.py
+++ b/core/security/credential_store.py
@@ -1,0 +1,25 @@
+"""Abstract base class for credential storage backends."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class CredentialStore(ABC):
+    """Interface for secure credential storage."""
+
+    @abstractmethod
+    def get(self, key: str) -> str | None:
+        """Retrieve a credential by key. Returns None if not found."""
+
+    @abstractmethod
+    def set(self, key: str, value: str) -> None:
+        """Store a credential."""
+
+    @abstractmethod
+    def delete(self, key: str) -> bool:
+        """Delete a credential. Returns True if it existed."""
+
+    @abstractmethod
+    def list_keys(self) -> list[str]:
+        """List all stored credential keys."""

--- a/core/security/dpop.py
+++ b/core/security/dpop.py
@@ -1,0 +1,91 @@
+"""DPoP (Demonstrating Proof-of-Possession) proof generator.
+
+Implements RFC 9449 — DPoP proof JWTs for sender-constrained access tokens.
+Uses ephemeral EC P-256 key pairs; each ``DPoPProofGenerator`` instance holds
+one key pair for its lifetime.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import secrets
+import time
+
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _int_to_b64url(n: int, length: int) -> str:
+    return _b64url(n.to_bytes(length, byteorder="big"))
+
+
+class DPoPProofGenerator:
+    """Generate DPoP proof JWTs per RFC 9449.
+
+    Each instance creates an ephemeral EC P-256 key pair.
+    """
+
+    def __init__(self) -> None:
+        self._private_key = ec.generate_private_key(ec.SECP256R1())
+        self._public_key = self._private_key.public_key()
+        pub_numbers = self._public_key.public_numbers()
+        self._jwk = {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": _int_to_b64url(pub_numbers.x, 32),
+            "y": _int_to_b64url(pub_numbers.y, 32),
+        }
+
+    def generate_proof(
+        self,
+        method: str,
+        url: str,
+        *,
+        access_token: str | None = None,
+    ) -> str:
+        """Generate a DPoP proof JWT.
+
+        Parameters
+        ----------
+        method:
+            HTTP method (GET, POST, etc.).
+        url:
+            The HTTP request URI.
+        access_token:
+            If provided, the ``ath`` (access token hash) claim is included.
+        """
+        header = {
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": self._jwk,
+        }
+
+        payload: dict[str, object] = {
+            "htm": method.upper(),
+            "htu": url,
+            "iat": int(time.time()),
+            "jti": secrets.token_urlsafe(16),
+        }
+
+        if access_token is not None:
+            token_hash = hashlib.sha256(access_token.encode("ascii")).digest()
+            payload["ath"] = _b64url(token_hash)
+
+        header_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode())
+        payload_b64 = _b64url(json.dumps(payload, separators=(",", ":")).encode())
+
+        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+        der_sig = self._private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+
+        r, s = decode_dss_signature(der_sig)
+        sig_bytes = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+        sig_b64 = _b64url(sig_bytes)
+
+        return f"{header_b64}.{payload_b64}.{sig_b64}"

--- a/core/security/file_store.py
+++ b/core/security/file_store.py
@@ -1,0 +1,58 @@
+"""File-based credential store — fallback when system keyring is unavailable."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+from core.security.credential_store import CredentialStore
+
+
+class FileStore(CredentialStore):
+    """Store credentials in a JSON file with restricted permissions.
+
+    Used as a fallback when system keyring is not available.
+    Credentials are stored in ``<config_dir>/credentials.json`` with
+    mode 0600 (owner read/write only).
+    """
+
+    _FILENAME = "credentials.json"
+
+    def __init__(self, config_dir: str | None = None) -> None:
+        if config_dir is None:
+            config_dir = os.path.join(os.path.expanduser("~"), ".aura")
+        self._dir = Path(config_dir)
+        self._path = self._dir / self._FILENAME
+
+    def _read(self) -> dict[str, str]:
+        if not self._path.exists():
+            return {}
+        with open(self._path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _write(self, data: dict[str, str]) -> None:
+        self._dir.mkdir(parents=True, exist_ok=True)
+        with open(self._path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        os.chmod(self._path, stat.S_IRUSR | stat.S_IWUSR)
+
+    def get(self, key: str) -> str | None:
+        return self._read().get(key)
+
+    def set(self, key: str, value: str) -> None:
+        data = self._read()
+        data[key] = value
+        self._write(data)
+
+    def delete(self, key: str) -> bool:
+        data = self._read()
+        if key not in data:
+            return False
+        del data[key]
+        self._write(data)
+        return True
+
+    def list_keys(self) -> list[str]:
+        return list(self._read().keys())

--- a/core/security/http_client.py
+++ b/core/security/http_client.py
@@ -1,0 +1,33 @@
+"""HTTP client with DPoP proof-of-possession support."""
+
+from __future__ import annotations
+
+import requests
+
+from core.security.dpop import DPoPProofGenerator
+
+
+class DPoPSession(requests.Session):
+    """A requests.Session that automatically attaches DPoP proof headers.
+
+    Each session holds its own ephemeral key pair via ``DPoPProofGenerator``.
+    """
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._dpop = DPoPProofGenerator()
+
+    def request(self, method: str, url: str, **kwargs: object) -> requests.Response:
+        access_token = None
+        if "headers" in kwargs and isinstance(kwargs["headers"], dict):
+            auth = kwargs["headers"].get("Authorization", "")
+            if isinstance(auth, str) and auth.startswith("DPoP "):
+                access_token = auth[len("DPoP ") :]
+
+        proof = self._dpop.generate_proof(method, url, access_token=access_token)
+
+        headers = dict(kwargs.pop("headers", None) or {})  # type: ignore[arg-type]
+        headers["DPoP"] = proof
+        kwargs["headers"] = headers
+
+        return super().request(method, url, **kwargs)

--- a/core/security/keyring_store.py
+++ b/core/security/keyring_store.py
@@ -1,0 +1,46 @@
+"""System keyring credential store — preferred backend when available."""
+
+from __future__ import annotations
+
+from core.security.credential_store import CredentialStore
+
+try:
+    import keyring as _keyring
+
+    _KEYRING_AVAILABLE = True
+except ImportError:
+    _keyring = None  # type: ignore[assignment]
+    _KEYRING_AVAILABLE = False
+
+_SERVICE_NAME = "aura-cli"
+
+
+class KeyringStore(CredentialStore):
+    """Store credentials via the OS keyring (e.g. macOS Keychain, GNOME Keyring)."""
+
+    def __init__(self, service_name: str = _SERVICE_NAME) -> None:
+        if not _KEYRING_AVAILABLE:
+            raise RuntimeError("keyring package is not installed")
+        self._service = service_name
+        self._keys: set[str] = set()
+
+    def get(self, key: str) -> str | None:
+        value = _keyring.get_password(self._service, key)
+        if value is not None:
+            self._keys.add(key)
+        return value
+
+    def set(self, key: str, value: str) -> None:
+        _keyring.set_password(self._service, key, value)
+        self._keys.add(key)
+
+    def delete(self, key: str) -> bool:
+        try:
+            _keyring.delete_password(self._service, key)
+            self._keys.discard(key)
+            return True
+        except _keyring.errors.PasswordDeleteError:
+            return False
+
+    def list_keys(self) -> list[str]:
+        return sorted(self._keys)

--- a/core/security/store_factory.py
+++ b/core/security/store_factory.py
@@ -1,0 +1,35 @@
+"""Factory for selecting the best available credential store backend."""
+
+from __future__ import annotations
+
+import warnings
+
+from core.security.credential_store import CredentialStore
+from core.security.file_store import FileStore
+
+_FALLBACK_WARNING = (
+    "System keyring is not available; credentials will be stored in a local file. "
+    "Install a keyring backend for better security."
+)
+
+
+def get_credential_store() -> CredentialStore:
+    """Return the best available credential store.
+
+    Tries the system keyring first; falls back to file-based storage
+    with a user-visible warning.
+    """
+    try:
+        import keyring
+        import keyring.backends.fail
+
+        backend = keyring.get_keyring()
+        if isinstance(backend, keyring.backends.fail.Keyring):
+            raise RuntimeError("fail backend")
+
+        from core.security.keyring_store import KeyringStore
+
+        return KeyringStore()
+    except Exception:
+        warnings.warn(_FALLBACK_WARNING, UserWarning, stacklevel=2)
+        return FileStore()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
     "pytest-asyncio>=0.21",
+    "syrupy>=4.0.0",
     "httpx>=0.24",
     "anyio>=4.0",
     "ruff>=0.4",
@@ -77,6 +78,7 @@ testpaths = ["."]
 asyncio_mode = "auto"
 addopts = [
     "--strict-markers",
+    "--snapshot-warn-unused",
     "-q",
 ]
 markers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ networkx
 # Development / testing
 pytest>=7.0
 pytest-asyncio>=0.21
+syrupy>=4.0.0
 httpx>=0.24
 anyio>=4.0
 python-dotenv

--- a/tests/security/__snapshots__/test_golden_cli_output.ambr
+++ b/tests/security/__snapshots__/test_golden_cli_output.ambr
@@ -1,0 +1,21 @@
+# serializer version: 1
+# name: TestCLIOutputGolden.test_credential_store_subclasses
+  list([
+    'FileStore',
+  ])
+# ---
+# name: TestCLIOutputGolden.test_dpop_generator_class_name
+  'DPoPProofGenerator'
+# ---
+# name: TestCLIOutputGolden.test_dpop_session_class_name
+  'DPoPSession'
+# ---
+# name: TestCLIOutputGolden.test_file_store_default_filename
+  'credentials.json'
+# ---
+# name: TestCLIOutputGolden.test_main_help_includes_expected_sections
+  'AURA CLI'
+# ---
+# name: TestCLIOutputGolden.test_store_factory_fallback_warning_text
+  'System keyring is not available; credentials will be stored in a local file. Install a keyring backend for better security.'
+# ---

--- a/tests/security/__snapshots__/test_golden_credential_store.ambr
+++ b/tests/security/__snapshots__/test_golden_credential_store.ambr
@@ -1,0 +1,21 @@
+# serializer version: 1
+# name: TestCredentialStoreGolden.test_file_store_delete_returns_false_for_missing
+  False
+# ---
+# name: TestCredentialStoreGolden.test_file_store_get_missing_key
+  None
+# ---
+# name: TestCredentialStoreGolden.test_list_keys_after_set
+  list([
+    'anthropic_api_key',
+    'aura_api_key',
+    'openai_api_key',
+  ])
+# ---
+# name: TestCredentialStoreGolden.test_list_keys_empty_store
+  list([
+  ])
+# ---
+# name: TestCredentialStoreGolden.test_store_factory_warning_message
+  'System keyring is not available; credentials will be stored in a local file. Install a keyring backend for better security.'
+# ---

--- a/tests/security/__snapshots__/test_golden_dpop.ambr
+++ b/tests/security/__snapshots__/test_golden_dpop.ambr
@@ -1,0 +1,31 @@
+# serializer version: 1
+# name: TestDPoPGoldenStructure.test_proof_header_structure
+  dict({
+    'alg': 'ES256',
+    'jwk_crv': 'P-256',
+    'jwk_kty': 'EC',
+    'typ': 'dpop+jwt',
+  })
+# ---
+# name: TestDPoPGoldenStructure.test_proof_is_three_parts
+  dict({
+    'parts': 3,
+    'pattern': 'base64url.base64url.base64url',
+    'separator': '.',
+  })
+# ---
+# name: TestDPoPGoldenStructure.test_proof_payload_structure_no_token
+  dict({
+    'htm': 'POST',
+    'htu': 'https://api.aura.example.com/v1/instances',
+    'iat': 1712678400,
+  })
+# ---
+# name: TestDPoPGoldenStructure.test_proof_payload_with_token
+  dict({
+    'ath': 'P4ojPsOHZTKstTWZilK68egjvqSCZl3R7N6DYRak0kE',
+    'htm': 'DELETE',
+    'htu': 'https://api.aura.example.com/v1/instances/abc-123',
+    'iat': 1712678400,
+  })
+# ---

--- a/tests/security/test_golden_cli_output.py
+++ b/tests/security/test_golden_cli_output.py
@@ -1,0 +1,59 @@
+"""
+Golden file tests for CLI output of security-related components.
+Verifies that help text, class names, and module repr don't drift.
+
+Update snapshots with: pytest --snapshot-update
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+class TestCLIOutputGolden:
+
+    def test_main_help_includes_expected_sections(self, snapshot):
+        """Top-level help output structure must match snapshot."""
+        result = subprocess.run(
+            [sys.executable, "main.py", "help"],
+            capture_output=True,
+            text=True,
+            cwd="/home/user/workspace/aura-cli-f77f9cbc",
+        )
+        # Extract only the first line (title) for deterministic snapshot
+        first_line = result.stdout.strip().split("\n")[0]
+        assert first_line == snapshot
+
+    def test_dpop_session_class_name(self, snapshot):
+        """DPoPSession type name must match snapshot for documentation purposes."""
+        from core.security.http_client import DPoPSession
+
+        session = DPoPSession()
+        assert type(session).__name__ == snapshot
+
+    def test_dpop_generator_class_name(self, snapshot):
+        """DPoPProofGenerator type name must match snapshot."""
+        from core.security.dpop import DPoPProofGenerator
+
+        gen = DPoPProofGenerator()
+        assert type(gen).__name__ == snapshot
+
+    def test_credential_store_subclasses(self, snapshot):
+        """Registered CredentialStore subclass names must match snapshot."""
+        from core.security.credential_store import CredentialStore
+
+        subclass_names = sorted(cls.__name__ for cls in CredentialStore.__subclasses__())
+        assert subclass_names == snapshot
+
+    def test_file_store_default_filename(self, snapshot):
+        """FileStore credential filename must match snapshot."""
+        from core.security.file_store import FileStore
+
+        assert FileStore._FILENAME == snapshot
+
+    def test_store_factory_fallback_warning_text(self, snapshot):
+        """The fallback warning constant must match snapshot."""
+        from core.security.store_factory import _FALLBACK_WARNING
+
+        assert _FALLBACK_WARNING == snapshot

--- a/tests/security/test_golden_credential_store.py
+++ b/tests/security/test_golden_credential_store.py
@@ -1,0 +1,60 @@
+"""
+Golden file tests for CredentialStore error messages and list output.
+Ensures user-facing strings don't drift unexpectedly.
+
+Update snapshots with: pytest --snapshot-update
+"""
+
+import warnings
+
+import pytest
+
+from core.security.file_store import FileStore
+
+
+class TestCredentialStoreGolden:
+
+    def test_store_factory_warning_message(self, snapshot):
+        """The fallback warning message must match snapshot exactly — user-visible string."""
+        import keyring
+        import keyring.backends.fail
+
+        original_backend = keyring.get_keyring()
+        keyring.set_keyring(keyring.backends.fail.Keyring())
+        try:
+            from core.security.store_factory import get_credential_store
+
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                store = get_credential_store()
+                if w:
+                    assert str(w[0].message) == snapshot
+                else:
+                    # If no warning emitted, the keyring worked — skip
+                    pytest.skip("Keyring available, no fallback warning emitted")
+        finally:
+            keyring.set_keyring(original_backend)
+
+    def test_list_keys_empty_store(self, tmp_path, snapshot):
+        """Empty store list output must match snapshot."""
+        store = FileStore(config_dir=str(tmp_path))
+        assert store.list_keys() == snapshot
+
+    def test_list_keys_after_set(self, tmp_path, snapshot):
+        """list_keys after setting deterministic keys must match snapshot."""
+        store = FileStore(config_dir=str(tmp_path))
+        store.set("openai_api_key", "sk-test")
+        store.set("anthropic_api_key", "ant-test")
+        store.set("aura_api_key", "aura-test")
+        # Sort for determinism
+        assert sorted(store.list_keys()) == snapshot
+
+    def test_file_store_get_missing_key(self, tmp_path, snapshot):
+        """Getting a nonexistent key must return the expected sentinel."""
+        store = FileStore(config_dir=str(tmp_path))
+        assert store.get("nonexistent_key") == snapshot
+
+    def test_file_store_delete_returns_false_for_missing(self, tmp_path, snapshot):
+        """Deleting a nonexistent key must return the expected boolean."""
+        store = FileStore(config_dir=str(tmp_path))
+        assert store.delete("nonexistent_key") == snapshot

--- a/tests/security/test_golden_dpop.py
+++ b/tests/security/test_golden_dpop.py
@@ -1,0 +1,77 @@
+"""
+Golden file (snapshot) tests for DPoP proof JWT structure.
+Verifies that the JWT structure never drifts unexpectedly across refactors.
+
+Update snapshots with: pytest --snapshot-update
+"""
+
+import base64
+import json
+
+import pytest
+
+from core.security.dpop import DPoPProofGenerator
+
+
+def decode_b64url(s: str) -> dict:
+    padding = "=" * (4 - len(s) % 4)
+    return json.loads(base64.urlsafe_b64decode(s + padding))
+
+
+@pytest.fixture
+def deterministic_generator(monkeypatch):
+    """
+    Returns a generator with mocked time and jti for deterministic snapshot output.
+    """
+    import secrets
+    import time
+
+    monkeypatch.setattr(time, "time", lambda: 1712678400.0)  # Fixed timestamp
+    monkeypatch.setattr(secrets, "token_urlsafe", lambda n=16: "FIXED_JTI_FOR_SNAPSHOT")
+    return DPoPProofGenerator()
+
+
+class TestDPoPGoldenStructure:
+
+    def test_proof_header_structure(self, deterministic_generator, snapshot):
+        """Header fields must match snapshot exactly."""
+        proof = deterministic_generator.generate_proof(
+            "GET", "https://api.aura.example.com/v1/instances"
+        )
+        header = decode_b64url(proof.split(".")[0])
+        # Snapshot the header (excluding the JWK x/y since EC key is always ephemeral)
+        assert {
+            "typ": header["typ"],
+            "alg": header["alg"],
+            "jwk_kty": header["jwk"]["kty"],
+            "jwk_crv": header["jwk"]["crv"],
+        } == snapshot
+
+    def test_proof_payload_structure_no_token(self, deterministic_generator, snapshot):
+        """Payload without access_token must match snapshot structure."""
+        proof = deterministic_generator.generate_proof(
+            "POST", "https://api.aura.example.com/v1/instances"
+        )
+        payload = decode_b64url(proof.split(".")[1])
+        # Snapshot all fields except jti (mocked but exclude for safety)
+        assert {k: v for k, v in payload.items() if k != "jti"} == snapshot
+
+    def test_proof_payload_with_token(self, deterministic_generator, snapshot):
+        """Payload with access_token must include ath claim — snapshot its structure."""
+        proof = deterministic_generator.generate_proof(
+            "DELETE",
+            "https://api.aura.example.com/v1/instances/abc-123",
+            access_token="test_bearer_token_for_snapshot",
+        )
+        payload = decode_b64url(proof.split(".")[1])
+        assert {k: v for k, v in payload.items() if k != "jti"} == snapshot
+
+    def test_proof_is_three_parts(self, deterministic_generator, snapshot):
+        """A DPoP proof must always be exactly 3 base64url parts separated by dots."""
+        proof = deterministic_generator.generate_proof("GET", "https://api.example.com")
+        structure = {
+            "parts": len(proof.split(".")),
+            "separator": ".",
+            "pattern": "base64url.base64url.base64url",
+        }
+        assert structure == snapshot


### PR DESCRIPTION
## Summary

- Add `core/security/` modules: DPoP proof generator (RFC 9449), credential store abstraction with file-based and keyring backends, store factory with fallback, and DPoP-aware HTTP client
- Add **15 syrupy snapshot tests** across 3 test files to catch unintended output drift:
  - `test_golden_dpop.py` (4 tests): JWT header structure, payload with/without access token, three-part format
  - `test_golden_credential_store.py` (5 tests): factory fallback warning, empty/populated key listing, missing key/delete behavior
  - `test_golden_cli_output.py` (6 tests): CLI help title, class names, subclass registry, constants
- Add `syrupy>=4.0.0` to dev dependencies (`pyproject.toml` + `requirements.txt`)
- Configure `--snapshot-warn-unused` in pytest addopts
- Add golden file CI step in `.github/workflows/ci.yml`
- Document snapshot update process in `CONTRIBUTING.md`

## Snapshot Files

Committed to `tests/security/__snapshots__/`:
- `test_golden_dpop.ambr`
- `test_golden_credential_store.ambr`
- `test_golden_cli_output.ambr`

## How to Update Snapshots

```bash
pytest tests/security/test_golden_*.py --snapshot-update
```

Review the diff in `tests/security/__snapshots__/` before committing — unexpected changes indicate a regression.

## Test plan

- [x] All 15 snapshot tests pass with `pytest tests/security/test_golden_*.py -v`
- [x] Tests also pass without `--snapshot-update` (no drift detected)
- [x] `--snapshot-warn-unused` enabled globally to catch stale snapshots
- [ ] CI runs golden file tests as a separate step

🤖 Generated with [Claude Code](https://claude.com/claude-code)