### PR TITLE
test: add Hypothesis property-based tests for CredentialStore and DPoP (Phase 2a)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
     - name: Test with pytest + coverage
       run: |
         pytest -q --maxfail=3 --cov=aura_cli --cov=core --cov=agents --cov=memory --cov-report=xml --cov-report=term-missing
+    - name: Run property-based tests
+      run: pytest tests/security/test_pbt_*.py -v --hypothesis-seed=0
+      env:
+        HYPOTHESIS_PROFILE: ci
     - name: Upload coverage
       if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/core/security/__init__.py
+++ b/core/security/__init__.py
@@ -1,0 +1,14 @@
+"""Security modules for AURA CLI.
+
+Provides credential storage, DPoP proof generation, and secure HTTP clients.
+"""
+
+from core.security.credential_store import CredentialStore
+from core.security.dpop import DPoPProofGenerator
+from core.security.store_factory import create_credential_store
+
+__all__ = [
+    "CredentialStore",
+    "DPoPProofGenerator",
+    "create_credential_store",
+]

--- a/core/security/credential_store.py
+++ b/core/security/credential_store.py
@@ -1,0 +1,54 @@
+"""Abstract credential store interface.
+
+Defines the contract for credential storage backends.
+All implementations must support set/get/delete/list_keys operations.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class CredentialStore(ABC):
+    """Abstract base class for credential storage backends."""
+
+    @abstractmethod
+    def set(self, name: str, secret: str) -> None:
+        """Store a credential.
+
+        Args:
+            name: Credential identifier (non-empty string).
+            secret: Secret value to store.
+
+        Raises:
+            ValueError: If name is empty.
+        """
+
+    @abstractmethod
+    def get(self, name: str) -> str | None:
+        """Retrieve a stored credential.
+
+        Args:
+            name: Credential identifier.
+
+        Returns:
+            The secret value, or None if not found.
+        """
+
+    @abstractmethod
+    def delete(self, name: str) -> None:
+        """Delete a stored credential.
+
+        Does not raise if the credential does not exist.
+
+        Args:
+            name: Credential identifier.
+        """
+
+    @abstractmethod
+    def list_keys(self) -> list[str]:
+        """List all stored credential names.
+
+        Returns:
+            List of credential identifiers.
+        """

--- a/core/security/dpop.py
+++ b/core/security/dpop.py
@@ -1,0 +1,117 @@
+"""RFC 9449 DPoP (Demonstrating Proof-of-Possession) proof generator.
+
+Generates DPoP proofs using ephemeral ECDSA P-256 key pairs.
+Each DPoPProofGenerator instance holds one ephemeral key pair;
+each call to generate_proof produces a fresh JWT with a unique jti.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+import uuid
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+
+
+def _b64url_encode(data: bytes) -> str:
+    """Base64url encode without padding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(s: str) -> bytes:
+    """Base64url decode with padding restoration."""
+    padding = 4 - len(s) % 4
+    if padding != 4:
+        s += "=" * padding
+    return base64.urlsafe_b64decode(s)
+
+
+def _int_to_b64url(n: int, length: int) -> str:
+    """Encode an integer as a base64url string of the given byte length."""
+    return _b64url_encode(n.to_bytes(length, byteorder="big"))
+
+
+class DPoPProofGenerator:
+    """Generates DPoP proofs per RFC 9449.
+
+    Each instance generates an ephemeral ECDSA P-256 key pair.
+    The public key is embedded in the JWT header as a JWK.
+    """
+
+    def __init__(self) -> None:
+        self._private_key = ec.generate_private_key(ec.SECP256R1())
+        self._public_key = self._private_key.public_key()
+        self._jwk = self._build_jwk()
+
+    def _build_jwk(self) -> dict:
+        """Build the JWK representation of the public key."""
+        public_numbers = self._public_key.public_numbers()
+        return {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": _int_to_b64url(public_numbers.x, 32),
+            "y": _int_to_b64url(public_numbers.y, 32),
+        }
+
+    @property
+    def public_jwk(self) -> dict:
+        """Return the public JWK."""
+        return dict(self._jwk)
+
+    def generate_proof(
+        self,
+        htm: str,
+        htu: str,
+        access_token: str | None = None,
+    ) -> str:
+        """Generate a DPoP proof JWT.
+
+        Args:
+            htm: HTTP method (will be uppercased).
+            htu: HTTP target URI.
+            access_token: Optional access token for ath claim.
+
+        Returns:
+            A compact-serialized JWT string (header.payload.signature).
+        """
+        header = {
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": self._jwk,
+        }
+
+        payload: dict = {
+            "jti": str(uuid.uuid4()),
+            "htm": htm.upper(),
+            "htu": htu,
+            "iat": int(time.time()),
+        }
+
+        if access_token is not None:
+            token_hash = hashlib.sha256(access_token.encode("utf-8")).digest()
+            payload["ath"] = _b64url_encode(token_hash)
+
+        header_b64 = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
+        payload_b64 = _b64url_encode(
+            json.dumps(payload, separators=(",", ":")).encode()
+        )
+
+        signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+
+        # Sign with ECDSA using SHA-256
+        der_signature = self._private_key.sign(
+            signing_input, ec.ECDSA(hashes.SHA256())
+        )
+
+        # Convert DER signature to raw r||s format (64 bytes for P-256)
+        r, s = utils.decode_dss_signature(der_signature)
+        raw_signature = r.to_bytes(32, byteorder="big") + s.to_bytes(
+            32, byteorder="big"
+        )
+        signature_b64 = _b64url_encode(raw_signature)
+
+        return f"{header_b64}.{payload_b64}.{signature_b64}"

--- a/core/security/file_store.py
+++ b/core/security/file_store.py
@@ -1,0 +1,77 @@
+"""Fernet-encrypted file-backed credential store.
+
+Falls back to this when the OS keyring is unavailable. Credentials are
+encrypted with a Fernet key derived from a master password or stored
+in a key file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+from core.security.credential_store import CredentialStore
+
+_DEFAULT_DIR = Path.home() / ".aura" / "credentials"
+
+
+class FileStore(CredentialStore):
+    """Credential store backed by Fernet-encrypted JSON files."""
+
+    def __init__(
+        self,
+        store_dir: Path | str | None = None,
+        fernet_key: bytes | None = None,
+    ) -> None:
+        self._dir = Path(store_dir) if store_dir else _DEFAULT_DIR
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+        key_file = self._dir / ".key"
+        if fernet_key:
+            self._fernet = Fernet(fernet_key)
+            if not key_file.exists():
+                key_file.write_bytes(fernet_key)
+                os.chmod(key_file, 0o600)
+        elif key_file.exists():
+            self._fernet = Fernet(key_file.read_bytes().strip())
+        else:
+            new_key = Fernet.generate_key()
+            key_file.write_bytes(new_key)
+            os.chmod(key_file, 0o600)
+            self._fernet = Fernet(new_key)
+
+        self._store_file = self._dir / "store.enc"
+        self._data: dict[str, str] = self._load()
+
+    def set(self, name: str, secret: str) -> None:
+        if not name:
+            raise ValueError("Credential name must not be empty")
+        self._data[name] = secret
+        self._save()
+
+    def get(self, name: str) -> str | None:
+        return self._data.get(name)
+
+    def delete(self, name: str) -> None:
+        self._data.pop(name, None)
+        self._save()
+
+    def list_keys(self) -> list[str]:
+        return list(self._data.keys())
+
+    def _load(self) -> dict[str, str]:
+        if not self._store_file.exists():
+            return {}
+        encrypted = self._store_file.read_bytes()
+        if not encrypted:
+            return {}
+        decrypted = self._fernet.decrypt(encrypted)
+        return json.loads(decrypted.decode("utf-8"))
+
+    def _save(self) -> None:
+        raw = json.dumps(self._data).encode("utf-8")
+        encrypted = self._fernet.encrypt(raw)
+        self._store_file.write_bytes(encrypted)

--- a/core/security/http_client.py
+++ b/core/security/http_client.py
@@ -1,0 +1,76 @@
+"""DPoP-aware HTTP session wrapper.
+
+Automatically attaches DPoP proof headers to outgoing requests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from core.security.dpop import DPoPProofGenerator
+
+
+class DPoPSession:
+    """HTTP session that automatically attaches DPoP proofs.
+
+    Wraps requests.Session to inject a DPoP header on every request.
+    """
+
+    def __init__(
+        self,
+        access_token: str | None = None,
+        generator: DPoPProofGenerator | None = None,
+    ) -> None:
+        self._session = requests.Session()
+        self._generator = generator or DPoPProofGenerator()
+        self._access_token = access_token
+
+    @property
+    def generator(self) -> DPoPProofGenerator:
+        """Return the DPoP proof generator."""
+        return self._generator
+
+    def request(self, method: str, url: str, **kwargs: Any) -> requests.Response:
+        """Send an HTTP request with a DPoP proof header.
+
+        Args:
+            method: HTTP method (GET, POST, etc.).
+            url: Target URL.
+            **kwargs: Additional arguments passed to requests.Session.request.
+
+        Returns:
+            The HTTP response.
+        """
+        proof = self._generator.generate_proof(
+            htm=method,
+            htu=url,
+            access_token=self._access_token,
+        )
+        headers = kwargs.pop("headers", {}) or {}
+        headers["DPoP"] = proof
+        if self._access_token:
+            headers.setdefault("Authorization", f"DPoP {self._access_token}")
+        return self._session.request(method, url, headers=headers, **kwargs)
+
+    def get(self, url: str, **kwargs: Any) -> requests.Response:
+        return self.request("GET", url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> requests.Response:
+        return self.request("POST", url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> requests.Response:
+        return self.request("PUT", url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> requests.Response:
+        return self.request("DELETE", url, **kwargs)
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __enter__(self) -> DPoPSession:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()

--- a/core/security/keyring_store.py
+++ b/core/security/keyring_store.py
@@ -1,0 +1,75 @@
+"""OS keyring-backed credential store.
+
+Uses the system keyring (macOS Keychain, Windows Credential Locker,
+Linux Secret Service) to store credentials securely.
+"""
+
+from __future__ import annotations
+
+from core.security.credential_store import CredentialStore
+
+try:
+    import keyring as _keyring
+
+    KEYRING_AVAILABLE = True
+except ImportError:
+    _keyring = None  # type: ignore[assignment]
+    KEYRING_AVAILABLE = False
+
+
+_SERVICE_NAME = "aura-cli"
+_INDEX_KEY = "__aura_cli_keys__"
+_INDEX_SEP = "\x00"
+
+
+class KeyringStore(CredentialStore):
+    """Credential store backed by the OS keyring."""
+
+    def __init__(self, service_name: str = _SERVICE_NAME) -> None:
+        if not KEYRING_AVAILABLE:
+            raise RuntimeError(
+                "keyring package not installed. Install with: pip install keyring"
+            )
+        self._service = service_name
+
+    def set(self, name: str, secret: str) -> None:
+        if not name:
+            raise ValueError("Credential name must not be empty")
+        _keyring.set_password(self._service, name, secret)
+        self._add_to_index(name)
+
+    def get(self, name: str) -> str | None:
+        return _keyring.get_password(self._service, name)
+
+    def delete(self, name: str) -> None:
+        try:
+            _keyring.delete_password(self._service, name)
+        except _keyring.errors.PasswordDeleteError:
+            pass
+        self._remove_from_index(name)
+
+    def list_keys(self) -> list[str]:
+        raw = _keyring.get_password(self._service, _INDEX_KEY)
+        if not raw:
+            return []
+        return [k for k in raw.split(_INDEX_SEP) if k]
+
+    def _add_to_index(self, name: str) -> None:
+        keys = set(self.list_keys())
+        keys.add(name)
+        _keyring.set_password(
+            self._service, _INDEX_KEY, _INDEX_SEP.join(sorted(keys))
+        )
+
+    def _remove_from_index(self, name: str) -> None:
+        keys = set(self.list_keys())
+        keys.discard(name)
+        if keys:
+            _keyring.set_password(
+                self._service, _INDEX_KEY, _INDEX_SEP.join(sorted(keys))
+            )
+        else:
+            try:
+                _keyring.delete_password(self._service, _INDEX_KEY)
+            except _keyring.errors.PasswordDeleteError:
+                pass

--- a/core/security/store_factory.py
+++ b/core/security/store_factory.py
@@ -1,0 +1,41 @@
+"""Auto-detection factory for credential stores.
+
+Attempts KeyringStore first; falls back to FileStore if the keyring
+is unavailable or unusable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.security.credential_store import CredentialStore
+
+
+def create_credential_store(
+    store_dir: Path | str | None = None,
+) -> CredentialStore:
+    """Create the best available credential store.
+
+    Attempts to use the OS keyring first. If keyring is not available
+    or not functional, falls back to Fernet-encrypted file store.
+
+    Args:
+        store_dir: Directory for file-based fallback storage.
+
+    Returns:
+        A CredentialStore instance.
+    """
+    try:
+        from core.security.keyring_store import KEYRING_AVAILABLE, KeyringStore
+
+        if KEYRING_AVAILABLE:
+            store = KeyringStore()
+            # Smoke-test: try a no-op to verify the backend works
+            store.list_keys()
+            return store
+    except Exception:
+        pass
+
+    from core.security.file_store import FileStore
+
+    return FileStore(store_dir=store_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
     "bandit>=1.7",
     "pip-audit>=2.7",
     "pre-commit>=3.0",
+    "hypothesis>=6.100.0",
+    "hypothesis[cli]",
+    "cryptography>=41.0",
 ]
 github = [
     "PyGithub>=2.1.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ networkx
 # Development / testing
 pytest>=7.0
 pytest-asyncio>=0.21
+hypothesis>=6.100.0
+cryptography>=41.0
 httpx>=0.24
 anyio>=4.0
 python-dotenv

--- a/tests/security/conftest.py
+++ b/tests/security/conftest.py
@@ -1,0 +1,26 @@
+"""Hypothesis profiles and shared fixtures for security tests."""
+
+from __future__ import annotations
+
+import os
+
+from hypothesis import HealthCheck, settings
+
+# Register Hypothesis profiles for different environments
+settings.register_profile(
+    "ci",
+    max_examples=100,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.register_profile(
+    "dev",
+    max_examples=500,
+)
+settings.register_profile(
+    "thorough",
+    max_examples=10000,
+)
+
+# Default to CI profile; override via HYPOTHESIS_PROFILE env var
+_profile = os.environ.get("HYPOTHESIS_PROFILE", "ci")
+settings.load_profile(_profile)

--- a/tests/security/test_credential_store.py
+++ b/tests/security/test_credential_store.py
@@ -1,0 +1,61 @@
+"""Unit tests for credential store implementations."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.security.file_store import FileStore
+
+
+@pytest.fixture()
+def file_store(tmp_path):
+    """Create a FileStore backed by a temporary directory."""
+    return FileStore(store_dir=tmp_path / "creds")
+
+
+class TestFileStore:
+    """Tests for FileStore (Fernet-encrypted file backend)."""
+
+    def test_set_and_get(self, file_store):
+        file_store.set("token", "secret123")
+        assert file_store.get("token") == "secret123"
+
+    def test_get_missing_returns_none(self, file_store):
+        assert file_store.get("nonexistent") is None
+
+    def test_delete_existing(self, file_store):
+        file_store.set("token", "secret123")
+        file_store.delete("token")
+        assert file_store.get("token") is None
+
+    def test_delete_nonexistent_does_not_raise(self, file_store):
+        file_store.delete("nonexistent")  # should not raise
+
+    def test_list_keys_empty(self, file_store):
+        assert file_store.list_keys() == []
+
+    def test_list_keys_after_set(self, file_store):
+        file_store.set("a", "1")
+        file_store.set("b", "2")
+        assert sorted(file_store.list_keys()) == ["a", "b"]
+
+    def test_overwrite(self, file_store):
+        file_store.set("token", "old")
+        file_store.set("token", "new")
+        assert file_store.get("token") == "new"
+
+    def test_empty_name_raises(self, file_store):
+        with pytest.raises(ValueError, match="empty"):
+            file_store.set("", "secret")
+
+    def test_persistence_across_instances(self, tmp_path):
+        store_dir = tmp_path / "creds"
+        store1 = FileStore(store_dir=store_dir)
+        store1.set("token", "persisted")
+
+        store2 = FileStore(store_dir=store_dir)
+        assert store2.get("token") == "persisted"
+
+    def test_unicode_secret(self, file_store):
+        file_store.set("emoji", "Hello 🌍🎉")
+        assert file_store.get("emoji") == "Hello 🌍🎉"

--- a/tests/security/test_dpop.py
+++ b/tests/security/test_dpop.py
@@ -1,0 +1,97 @@
+"""Unit tests for DPoP proof generator."""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+
+from core.security.dpop import DPoPProofGenerator, _b64url_decode
+
+
+def _decode_jwt_parts(token: str) -> tuple[dict, dict]:
+    """Decode header and payload from a compact JWT."""
+    parts = token.split(".")
+    header = json.loads(_b64url_decode(parts[0]))
+    payload = json.loads(_b64url_decode(parts[1]))
+    return header, payload
+
+
+class TestDPoPProofGenerator:
+    """Tests for DPoPProofGenerator."""
+
+    def test_proof_is_three_part_jwt(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com")
+        assert re.match(r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$", proof)
+
+    def test_header_typ_and_alg(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("POST", "https://example.com/api")
+        header, _ = _decode_jwt_parts(proof)
+        assert header["typ"] == "dpop+jwt"
+        assert header["alg"] == "ES256"
+
+    def test_header_contains_jwk(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com")
+        header, _ = _decode_jwt_parts(proof)
+        jwk = header["jwk"]
+        assert jwk["kty"] == "EC"
+        assert jwk["crv"] == "P-256"
+        assert "x" in jwk
+        assert "y" in jwk
+
+    def test_payload_required_fields(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com/resource")
+        _, payload = _decode_jwt_parts(proof)
+        assert payload["htm"] == "GET"
+        assert payload["htu"] == "https://example.com/resource"
+        assert "jti" in payload
+        assert "iat" in payload
+
+    def test_iat_is_recent(self):
+        gen = DPoPProofGenerator()
+        now = int(time.time())
+        proof = gen.generate_proof("GET", "https://example.com")
+        _, payload = _decode_jwt_parts(proof)
+        assert abs(payload["iat"] - now) <= 2
+
+    def test_jti_is_unique(self):
+        gen = DPoPProofGenerator()
+        jtis = set()
+        for _ in range(100):
+            proof = gen.generate_proof("GET", "https://example.com")
+            _, payload = _decode_jwt_parts(proof)
+            jtis.add(payload["jti"])
+        assert len(jtis) == 100
+
+    def test_ath_present_when_access_token_given(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com", access_token="tok123")
+        _, payload = _decode_jwt_parts(proof)
+        assert "ath" in payload
+
+    def test_ath_absent_when_no_access_token(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com")
+        _, payload = _decode_jwt_parts(proof)
+        assert "ath" not in payload
+
+    def test_method_uppercased(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("get", "https://example.com")
+        _, payload = _decode_jwt_parts(proof)
+        assert payload["htm"] == "GET"
+
+    def test_public_jwk_matches_header(self):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com")
+        header, _ = _decode_jwt_parts(proof)
+        assert header["jwk"] == gen.public_jwk
+
+    def test_different_generators_different_keys(self):
+        gen1 = DPoPProofGenerator()
+        gen2 = DPoPProofGenerator()
+        assert gen1.public_jwk != gen2.public_jwk

--- a/tests/security/test_pbt_credential_store.py
+++ b/tests/security/test_pbt_credential_store.py
@@ -1,0 +1,154 @@
+"""Property-based tests for CredentialStore implementations.
+
+Uses Hypothesis to verify algebraic properties of credential stores:
+round-trip, overwrite, delete, non-interference, and key listing.
+
+Inspired by Vikram et al. (2024) "Can LLMs Write Good Property-Based Tests?"
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from core.security.file_store import FileStore
+
+# Strategy for valid credential names: non-empty, no surrogate chars
+_name_st = st.text(
+    min_size=1,
+    max_size=128,
+    alphabet=st.characters(blacklist_categories=("Cs",)),
+)
+
+# Strategy for credential secrets: non-empty strings
+_secret_st = st.text(min_size=1, max_size=4096)
+
+# Strategy for Unicode secrets including emoji, CJK, RTL
+_unicode_secret_st = st.text(
+    min_size=1,
+    max_size=512,
+    alphabet=st.characters(
+        min_codepoint=0,
+        max_codepoint=0x10FFFF,
+        blacklist_categories=("Cs",),
+    ),
+)
+
+
+def _make_store() -> FileStore:
+    """Create a fresh FileStore in a temporary directory."""
+    tmp = tempfile.mkdtemp()
+    return FileStore(store_dir=Path(tmp) / "creds")
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Round-trip — set then get returns the original secret
+# ---------------------------------------------------------------------------
+class TestRoundTrip:
+    @given(name=_name_st, secret=_secret_st)
+    def test_set_get_roundtrip(self, name, secret):
+        store = _make_store()
+        store.set(name, secret)
+        assert store.get(name) == secret
+
+
+# ---------------------------------------------------------------------------
+# Property 2: Delete removes entry
+# ---------------------------------------------------------------------------
+class TestDeleteRemoves:
+    @given(name=_name_st, secret=_secret_st)
+    def test_delete_removes_entry(self, name, secret):
+        store = _make_store()
+        store.set(name, secret)
+        store.delete(name)
+        assert store.get(name) is None
+
+
+# ---------------------------------------------------------------------------
+# Property 3: Overwrite — latest write wins
+# ---------------------------------------------------------------------------
+class TestOverwrite:
+    @given(name=_name_st, secret1=_secret_st, secret2=_secret_st)
+    def test_latest_write_wins(self, name, secret1, secret2):
+        store = _make_store()
+        store.set(name, secret1)
+        store.set(name, secret2)
+        assert store.get(name) == secret2
+
+
+# ---------------------------------------------------------------------------
+# Property 4: Non-interference — setting key A does not affect key B
+# ---------------------------------------------------------------------------
+class TestNonInterference:
+    @given(
+        name_a=_name_st,
+        name_b=_name_st,
+        secret_a=_secret_st,
+        secret_b=_secret_st,
+    )
+    def test_setting_a_does_not_affect_b(self, name_a, name_b, secret_a, secret_b):
+        assume(name_a != name_b)
+        store = _make_store()
+        store.set(name_a, secret_a)
+        store.set(name_b, secret_b)
+        # Re-setting A should not change B
+        store.set(name_a, "overwritten")
+        assert store.get(name_b) == secret_b
+
+
+# ---------------------------------------------------------------------------
+# Property 5: Empty secret handling — store.set(name, "") stores empty string
+# ---------------------------------------------------------------------------
+class TestEmptySecret:
+    @given(name=_name_st)
+    def test_empty_secret_stores_empty_string(self, name):
+        store = _make_store()
+        store.set(name, "")
+        assert store.get(name) == ""
+
+
+# ---------------------------------------------------------------------------
+# Property 6: Unicode secrets survive round-trip through Fernet encryption
+# ---------------------------------------------------------------------------
+class TestUnicodeRoundTrip:
+    @given(name=_name_st, secret=_unicode_secret_st)
+    def test_unicode_secrets_roundtrip(self, name, secret):
+        store = _make_store()
+        store.set(name, secret)
+        assert store.get(name) == secret
+
+
+# ---------------------------------------------------------------------------
+# Property 7: list_keys reflects all stored keys
+# ---------------------------------------------------------------------------
+class TestListKeys:
+    @given(
+        keys=st.lists(
+            _name_st,
+            min_size=1,
+            max_size=20,
+            unique=True,
+        )
+    )
+    def test_list_reflects_stored_keys(self, keys):
+        store = _make_store()
+        for k in keys:
+            store.set(k, "value")
+        stored = set(store.list_keys())
+        assert set(keys).issubset(stored)
+
+
+# ---------------------------------------------------------------------------
+# Property 8: Idempotent delete — deleting a non-existent key does not raise
+# ---------------------------------------------------------------------------
+class TestIdempotentDelete:
+    @given(name=_name_st)
+    def test_delete_nonexistent_does_not_raise(self, name):
+        store = _make_store()
+        # Ensure key does not exist, then delete
+        store.delete(name)
+        # Deleting again should also not raise
+        store.delete(name)

--- a/tests/security/test_pbt_dpop.py
+++ b/tests/security/test_pbt_dpop.py
@@ -1,0 +1,188 @@
+"""Property-based tests for DPoP proof generator.
+
+Uses Hypothesis to verify structural and cryptographic properties of
+DPoP proofs per RFC 9449.
+
+Inspired by Vikram et al. (2024) "Can LLMs Write Good Property-Based Tests?"
+and flyingmutant/rapid.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.hazmat.primitives import hashes
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from core.security.dpop import DPoPProofGenerator, _b64url_decode, _b64url_encode
+
+# Strategies
+_http_methods = st.sampled_from(["GET", "POST", "PUT", "DELETE", "PATCH", "get", "post", "put", "delete", "patch"])
+_urls = st.from_regex(r"https://[a-z]{1,20}\.[a-z]{2,5}(/[a-z0-9]{1,15}){0,4}", fullmatch=True)
+_access_tokens = st.text(
+    min_size=1,
+    max_size=256,
+    alphabet=st.characters(blacklist_categories=("Cs",)),
+)
+
+
+def _decode_jwt(token: str) -> tuple[dict, dict, bytes]:
+    """Decode a compact JWT into (header, payload, signature_bytes)."""
+    parts = token.split(".")
+    header = json.loads(_b64url_decode(parts[0]))
+    payload = json.loads(_b64url_decode(parts[1]))
+    sig = _b64url_decode(parts[2])
+    return header, payload, sig
+
+
+# ---------------------------------------------------------------------------
+# Property 1: Proof is always a valid 3-part JWT
+# ---------------------------------------------------------------------------
+class TestJWTStructure:
+    @given(htm=_http_methods, htu=_urls)
+    def test_proof_is_three_part_jwt(self, htm, htu):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof(htm, htu)
+        assert re.match(
+            r"^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$", proof
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 2: Header always contains required fields
+# ---------------------------------------------------------------------------
+class TestHeaderFields:
+    @given(htm=_http_methods, htu=_urls)
+    def test_header_has_required_fields(self, htm, htu):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof(htm, htu)
+        header, _, _ = _decode_jwt(proof)
+
+        assert header["typ"] == "dpop+jwt"
+        assert header["alg"] == "ES256"
+        jwk = header["jwk"]
+        assert jwk["kty"] == "EC"
+        assert jwk["crv"] == "P-256"
+        assert "x" in jwk
+        assert "y" in jwk
+
+
+# ---------------------------------------------------------------------------
+# Property 3: Payload always contains required fields
+# ---------------------------------------------------------------------------
+class TestPayloadFields:
+    @given(htm=_http_methods, htu=_urls)
+    def test_payload_has_required_fields(self, htm, htu):
+        gen = DPoPProofGenerator()
+        now = int(time.time())
+        proof = gen.generate_proof(htm, htu)
+        _, payload, _ = _decode_jwt(proof)
+
+        assert payload["jti"]  # non-empty
+        assert payload["htm"] == htm.upper()
+        assert payload["htu"] == htu
+        assert isinstance(payload["iat"], int)
+        assert abs(payload["iat"] - now) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Property 4: jti uniqueness across many calls
+# ---------------------------------------------------------------------------
+class TestJtiUniqueness:
+    @settings(max_examples=1)
+    @given(st.just(None))
+    def test_jti_uniqueness_at_scale(self, _):
+        gen = DPoPProofGenerator()
+        jtis = set()
+        for _ in range(1000):
+            proof = gen.generate_proof("GET", "https://example.com")
+            _, payload, _ = _decode_jwt(proof)
+            jtis.add(payload["jti"])
+        assert len(jtis) == 1000
+
+
+# ---------------------------------------------------------------------------
+# Property 5: ath claim correctness
+# ---------------------------------------------------------------------------
+class TestAthClaim:
+    @given(access_token=_access_tokens)
+    def test_ath_is_correct_hash(self, access_token):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof("GET", "https://example.com", access_token=access_token)
+        _, payload, _ = _decode_jwt(proof)
+
+        assert "ath" in payload
+        expected = _b64url_encode(
+            hashlib.sha256(access_token.encode("utf-8")).digest()
+        )
+        assert payload["ath"] == expected
+
+    @given(htm=_http_methods, htu=_urls)
+    def test_ath_absent_without_token(self, htm, htu):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof(htm, htu)
+        _, payload, _ = _decode_jwt(proof)
+        assert "ath" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Property 6: Method normalization
+# ---------------------------------------------------------------------------
+class TestMethodNormalization:
+    @given(
+        method=st.sampled_from(["get", "Get", "GET", "post", "Post", "POST"]),
+        htu=_urls,
+    )
+    def test_htm_always_uppercased(self, method, htu):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof(method, htu)
+        _, payload, _ = _decode_jwt(proof)
+        assert payload["htm"] == method.upper()
+        assert payload["htm"] == payload["htm"].upper()
+
+
+# ---------------------------------------------------------------------------
+# Property 7: Signature verifies with the embedded public key
+# ---------------------------------------------------------------------------
+class TestSignatureVerification:
+    @given(htm=_http_methods, htu=_urls)
+    def test_signature_verifies(self, htm, htu):
+        gen = DPoPProofGenerator()
+        proof = gen.generate_proof(htm, htu)
+        parts = proof.split(".")
+        header, _, sig_bytes = _decode_jwt(proof)
+
+        signing_input = f"{parts[0]}.{parts[1]}".encode("ascii")
+
+        # Reconstruct public key from JWK
+        jwk = header["jwk"]
+        x = int.from_bytes(_b64url_decode(jwk["x"]), "big")
+        y = int.from_bytes(_b64url_decode(jwk["y"]), "big")
+        pub_numbers = ec.EllipticCurvePublicNumbers(x, y, ec.SECP256R1())
+        pub_key = pub_numbers.public_key()
+
+        # Convert raw r||s to DER
+        r = int.from_bytes(sig_bytes[:32], "big")
+        s = int.from_bytes(sig_bytes[32:], "big")
+        der_sig = utils.encode_dss_signature(r, s)
+
+        # Verify — raises InvalidSignature if wrong
+        pub_key.verify(der_sig, signing_input, ec.ECDSA(hashes.SHA256()))
+
+
+# ---------------------------------------------------------------------------
+# Property 8: Different generators produce different key material
+# ---------------------------------------------------------------------------
+class TestKeyUniqueness:
+    @settings(max_examples=50)
+    @given(st.just(None))
+    def test_different_generators_different_keys(self, _):
+        gen1 = DPoPProofGenerator()
+        gen2 = DPoPProofGenerator()
+        assert gen1.public_jwk != gen2.public_jwk


### PR DESCRIPTION
## Summary

- **Sprint 1 security modules**: Added `CredentialStore` (abstract interface), `FileStore` (Fernet-encrypted file backend), `KeyringStore` (OS keyring backend), `StoreFactory` (auto-detection), `DPoPProofGenerator` (RFC 9449 ES256), and `DPoPSession` (HTTP wrapper)
- **16 property-based tests** using Hypothesis across two test files covering algebraic properties of credential storage and cryptographic properties of DPoP proofs
- **Bug discovered by Hypothesis**: `DPoPProofGenerator.generate_proof()` encoded access tokens with ASCII (`access_token.encode("ascii")`), which crashes on non-ASCII tokens. Hypothesis shrunk the failing example to `'ª'` (U+00AA). Fixed to use UTF-8 encoding.
- **Hypothesis profiles**: `ci` (100 examples), `dev` (500), `thorough` (10000) — configured in `tests/security/conftest.py`
- **CI integration**: Added property-based test step to `.github/workflows/ci.yml` with `--hypothesis-seed=0` for reproducibility

## Properties Tested

### CredentialStore (8 properties — `test_pbt_credential_store.py`)
1. **Round-trip**: `set(name, secret)` then `get(name)` returns `secret` unchanged
2. **Delete removes entry**: After set+delete, `get` returns `None`
3. **Overwrite / latest-write-wins**: Second `set` overwrites first
4. **Non-interference**: Setting key A does not affect key B
5. **Empty secret storage**: `set(name, "")` stores empty string
6. **Unicode round-trip**: Emoji, CJK, RTL text survive Fernet encryption
7. **List keys consistency**: `list_keys()` contains all stored keys
8. **Idempotent delete**: Deleting non-existent key does not raise

### DPoP (8 properties — `test_pbt_dpop.py`)
1. **3-part JWT structure**: Proof always matches `header.payload.signature` format
2. **Required header fields**: `typ=dpop+jwt`, `alg=ES256`, `jwk` with `kty=EC`, `crv=P-256`
3. **Required payload fields**: `jti` (non-empty), `htm` (uppercased), `htu` (exact), `iat` (within 5s)
4. **jti uniqueness at scale**: 1000 proofs produce 1000 distinct jti values
5. **ath claim correctness**: `ath = base64url(SHA-256(access_token))` for any token
6. **Method normalization**: Mixed-case HTTP methods always uppercased in `htm`
7. **Signature verification**: ES256 signature verifies with embedded public key
8. **Ephemeral key uniqueness**: Different generators produce different key material

## Bug Found

| Property | Input (shrunk) | Root Cause | Fix |
|---|---|---|---|
| ath claim correctness | `access_token='ª'` (U+00AA) | `encode("ascii")` in `dpop.py:95` | Changed to `encode("utf-8")` |

## References
- Vikram et al. (2024) "Can LLMs Write Good Property-Based Tests?" — inspiration for property selection
- [flyingmutant/rapid](https://github.com/flyingmutant/rapid) — Go property-based testing framework that informed the property design

## Test plan
- [x] `pytest tests/security/ -v` — all 38 tests pass (10 unit credential + 11 unit DPoP + 8 PBT credential + 9 PBT DPoP)
- [ ] CI runs property-based tests with `HYPOTHESIS_PROFILE=ci` and `--hypothesis-seed=0`
- [ ] Verify Hypothesis profiles load correctly across `ci`/`dev`/`thorough`

🤖 Generated with [Claude Code](https://claude.com/claude-code)