### PR TITLE
feat: Sprint 9 — coverage fleet 25→28.95%, 1545 tests

### DIFF
--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -548,3 +548,489 @@ class TestMCPPortEnvOverrides:
             assert cm.get_mcp_server_port("dev_tools") == 8001
         finally:
             del os.environ["AURA_MCP_SERVERS_DEV_TOOLS_PORT"]
+
+
+# ---------------------------------------------------------------------------
+# Sprint-9 extended coverage (appended)
+# ---------------------------------------------------------------------------
+from unittest.mock import MagicMock, patch
+
+
+class TestIsPydanticAvailable:
+    def test_returns_bool(self):
+        from core.config_manager import is_pydantic_available
+        assert isinstance(is_pydantic_available(), bool)
+
+    def test_returns_true_when_available(self):
+        from core.config_manager import is_pydantic_available
+        try:
+            import pydantic  # noqa: F401
+            assert is_pydantic_available() is True
+        except ImportError:
+            assert is_pydantic_available() is False
+
+
+class TestConfigManagerUpdateConfig:
+    def test_update_config_persist_true(self, tmp_path):
+        config_file = tmp_path / "test.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        cm.update_config({"model_name": "persisted-model"}, persist=True)
+        data = json.loads(config_file.read_text())
+        assert data["model_name"] == "persisted-model"
+
+    def test_update_config_get_reflects_updated_value(self, tmp_path):
+        config_file = tmp_path / "test.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        cm.update_config({"model_name": "test-model-upd"}, persist=True)
+        assert cm.get("model_name") == "test-model-upd"
+
+    def test_update_config_deep_merge_beads(self, tmp_path):
+        config_file = tmp_path / "test.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        original_enabled = cm.get("beads")["enabled"]
+        cm.update_config({"beads": {"timeout_seconds": 99}}, persist=True)
+        beads = cm.get("beads")
+        assert beads["timeout_seconds"] == 99
+        assert beads["enabled"] == original_enabled
+
+    def test_update_config_deep_merge_model_routing(self, tmp_path):
+        config_file = tmp_path / "test.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        cm.update_config({"model_routing": {"fast": "my-fast-model"}}, persist=True)
+        routing = cm.get("model_routing")
+        assert routing["fast"] == "my-fast-model"
+        assert "planning" in routing
+
+    def test_update_config_deep_merge_semantic_memory(self, tmp_path):
+        config_file = tmp_path / "test.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        cm.update_config({"semantic_memory": {"top_k": 20}}, persist=True)
+        sm = cm.get("semantic_memory")
+        assert sm["top_k"] == 20
+        assert "enabled" in sm
+
+    def test_update_config_persist_write_error_raises(self, tmp_path):
+        config_file = tmp_path / "readonly.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        config_file.chmod(0o444)
+        try:
+            with pytest.raises(ConfigurationError):
+                cm.update_config({"model_name": "x"}, persist=True)
+        finally:
+            config_file.chmod(0o644)
+
+
+class TestPersistToFile:
+    def test_persist_to_file_saves_and_refreshes(self, tmp_path):
+        config_file = tmp_path / "cfg.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        cm.persist_to_file("max_iterations", 42)
+        data = json.loads(config_file.read_text())
+        assert data["max_iterations"] == 42
+        assert cm.get("max_iterations") == 42
+
+    def test_persist_to_file_raises_on_write_error(self, tmp_path):
+        config_file = tmp_path / "locked.json"
+        config_file.write_text("{}")
+        cm = ConfigManager(config_file=str(config_file))
+        config_file.chmod(0o444)
+        try:
+            with pytest.raises(ConfigurationError):
+                cm.persist_to_file("model_name", "x")
+        finally:
+            config_file.chmod(0o644)
+
+
+class TestGetMCPServerApiKey:
+    def test_unknown_server_raises(self):
+        cm = ConfigManager()
+        with pytest.raises(ConfigurationError, match="Unknown MCP server"):
+            cm.get_mcp_server_api_key("no_such_server")
+
+    def test_returns_env_var_value(self, monkeypatch):
+        monkeypatch.setenv("MCP_SKILLS_API_KEY", "env-token-123")
+        cm = ConfigManager()
+        result = cm.get_mcp_server_api_key("skills")
+        assert result == "env-token-123"
+
+    def test_returns_config_value_when_no_env(self, monkeypatch):
+        monkeypatch.delenv("MCP_SKILLS_API_KEY", raising=False)
+        cm = ConfigManager()
+        cm.effective_config["mcp_server_api_keys"] = {"skills": "cfg-key-abc"}
+        result = cm.get_mcp_server_api_key("skills")
+        assert result == "cfg-key-abc"
+
+    def test_legacy_dev_tools_fallback(self, monkeypatch):
+        monkeypatch.setenv("MCP_API_TOKEN", "legacy-token")
+        monkeypatch.delenv("MCP_DEV_TOOLS_API_KEY", raising=False)
+        cm = ConfigManager()
+        cm.effective_config["mcp_server_api_keys"] = {"dev_tools": None}
+        result = cm.get_mcp_server_api_key("dev_tools")
+        assert result == "legacy-token"
+
+    def test_env_var_priority_over_config(self, monkeypatch):
+        monkeypatch.setenv("MCP_CONTROL_API_KEY", "env-wins")
+        cm = ConfigManager()
+        cm.effective_config["mcp_server_api_keys"] = {"control": "config-loses"}
+        result = cm.get_mcp_server_api_key("control")
+        assert result == "env-wins"
+
+    def test_returns_none_when_nothing_configured(self, monkeypatch):
+        monkeypatch.delenv("MCP_SKILLS_API_KEY", raising=False)
+        cm = ConfigManager()
+        cm.effective_config["mcp_server_api_keys"] = {"skills": None}
+        result = cm.get_mcp_server_api_key("skills")
+        assert result is None
+
+
+class TestBootstrap:
+    def test_bootstrap_creates_config_when_absent(self, tmp_path):
+        config_file = tmp_path / "new.json"
+        assert not config_file.exists()
+        cm = ConfigManager(config_file=str(config_file))
+        if config_file.exists():
+            config_file.unlink()
+        cm.config_file = config_file
+        cm.bootstrap()
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert "model_name" in data
+
+    def test_bootstrap_skips_when_file_exists(self, tmp_path):
+        config_file = tmp_path / "existing.json"
+        config_file.write_text(json.dumps({"model_name": "keep-me"}))
+        cm = ConfigManager(config_file=str(config_file))
+        cm.bootstrap()
+        data = json.loads(config_file.read_text())
+        assert data["model_name"] == "keep-me"
+
+
+class TestMigrateCredentials:
+    def _make_cm_with_mock_store(self, tmp_path, file_config=None):
+        config_file = tmp_path / "cfg.json"
+        config_file.write_text(json.dumps(file_config or {}))
+        mock_store = MagicMock()
+        mock_store.store.return_value = True
+        mock_store.retrieve.return_value = None
+        mock_store.get_storage_info.return_value = {"backend": "mock"}
+        cm = ConfigManager(config_file=str(config_file), credential_store=mock_store)
+        return cm, mock_store
+
+    def test_dry_run_reports_what_would_migrate(self, tmp_path):
+        cm, store = self._make_cm_with_mock_store(tmp_path, {"api_key": "real-key-xyz"})
+        results = cm.migrate_credentials(dry_run=True)
+        assert "api_key" in results["migrated"]
+        assert results["dry_run"] is True
+        store.store.assert_not_called()
+
+    def test_not_found_when_key_absent(self, tmp_path):
+        cm, _ = self._make_cm_with_mock_store(tmp_path, {})
+        results = cm.migrate_credentials()
+        assert "api_key" in results["not_found"]
+
+    def test_already_secure_skipped(self, tmp_path):
+        cm, _ = self._make_cm_with_mock_store(tmp_path, {"api_key": "***SECURE_STORAGE***"})
+        results = cm.migrate_credentials()
+        assert "api_key" in results["already_secure"]
+
+    def test_placeholder_treated_as_not_found(self, tmp_path):
+        cm, _ = self._make_cm_with_mock_store(tmp_path, {"api_key": "YOUR_API_KEY_HERE"})
+        results = cm.migrate_credentials()
+        assert "api_key" in results["not_found"]
+
+    def test_actual_migration_stores_credential(self, tmp_path):
+        cm, mock_store = self._make_cm_with_mock_store(tmp_path, {"api_key": "real-key-abc"})
+        results = cm.migrate_credentials(dry_run=False)
+        assert "api_key" in results["migrated"]
+        mock_store.store.assert_called()
+
+    def test_migration_error_recorded(self, tmp_path):
+        cm, mock_store = self._make_cm_with_mock_store(tmp_path, {"api_key": "some-key"})
+        mock_store.store.side_effect = RuntimeError("keyring unavailable")
+        results = cm.migrate_credentials(dry_run=False)
+        assert "api_key" in results["errors"]
+
+    def test_store_returns_false_recorded_as_error(self, tmp_path):
+        cm, mock_store = self._make_cm_with_mock_store(tmp_path, {"api_key": "some-key"})
+        mock_store.store.return_value = False
+        results = cm.migrate_credentials(dry_run=False)
+        assert "api_key" in results["errors"]
+
+
+class TestCredentialStoreMethods:
+    def _make_cm(self):
+        mock_store = MagicMock()
+        mock_store.store.return_value = True
+        mock_store.retrieve.return_value = "stored-value"
+        mock_store.delete.return_value = True
+        mock_store.get_storage_info.return_value = {"backend": "mock", "available": True}
+        cm = ConfigManager(credential_store=mock_store)
+        return cm, mock_store
+
+    def test_secure_store_credential_delegates(self):
+        cm, mock = self._make_cm()
+        result = cm.secure_store_credential("api_key", "my-secret")
+        assert result is True
+        mock.store.assert_called_with("api_key", "my-secret")
+
+    def test_secure_retrieve_credential_delegates(self):
+        cm, mock = self._make_cm()
+        result = cm.secure_retrieve_credential("api_key")
+        assert result == "stored-value"
+        mock.retrieve.assert_called_with("api_key")
+
+    def test_secure_delete_credential_delegates(self):
+        cm, mock = self._make_cm()
+        result = cm.secure_delete_credential("api_key")
+        assert result is True
+        mock.delete.assert_called_with("api_key")
+
+    def test_get_credential_store_info_delegates(self):
+        cm, mock = self._make_cm()
+        info = cm.get_credential_store_info()
+        assert info["backend"] == "mock"
+        mock.get_storage_info.assert_called_once()
+
+
+class TestGetSecureKey:
+    def test_runtime_override_has_highest_priority(self):
+        mock_store = MagicMock()
+        mock_store.retrieve.return_value = "from_store"
+        cm = ConfigManager(overrides={"api_key": "from_override"}, credential_store=mock_store)
+        result = cm.get("api_key")
+        assert result == "from_override"
+
+    def test_non_secure_key_skips_credential_store(self):
+        mock_store = MagicMock()
+        mock_store.retrieve.return_value = "should_not_be_used"
+        cm = ConfigManager(credential_store=mock_store)
+        result = cm.get("max_iterations")
+        mock_store.retrieve.assert_not_called()
+        assert result is not None
+
+
+class TestEnvLoadingExtended:
+    def test_model_routing_env_override(self):
+        os.environ["AURA_MODEL_ROUTING_PLANNING"] = "my-plan-model"
+        try:
+            cm = ConfigManager()
+            cm.refresh()
+            routing = cm.get("model_routing")
+            assert routing["planning"] == "my-plan-model"
+        finally:
+            del os.environ["AURA_MODEL_ROUTING_PLANNING"]
+
+    def test_local_model_routing_env_override(self):
+        os.environ["AURA_LOCAL_MODEL_ROUTING_PLANNING"] = "local-plan"
+        try:
+            cm = ConfigManager()
+            cm.refresh()
+            lr = cm.get("local_model_routing")
+            assert lr["planning"] == "local-plan"
+        finally:
+            del os.environ["AURA_LOCAL_MODEL_ROUTING_PLANNING"]
+
+    def test_semantic_memory_bool_env_override(self):
+        os.environ["AURA_SEMANTIC_MEMORY_ENABLED"] = "false"
+        try:
+            cm = ConfigManager()
+            cm.refresh()
+            sm = cm.get("semantic_memory")
+            assert sm["enabled"] is False
+        finally:
+            del os.environ["AURA_SEMANTIC_MEMORY_ENABLED"]
+
+    def test_semantic_memory_int_env_override(self):
+        os.environ["AURA_SEMANTIC_MEMORY_TOP_K"] = "25"
+        try:
+            cm = ConfigManager()
+            cm.refresh()
+            sm = cm.get("semantic_memory")
+            assert sm["top_k"] == 25
+        finally:
+            del os.environ["AURA_SEMANTIC_MEMORY_TOP_K"]
+
+    def test_env_openrouter_api_key_mapping(self):
+        os.environ["OPENROUTER_API_KEY"] = "or-key-test"
+        try:
+            cm = ConfigManager()
+            cm.refresh()
+            assert cm.get("api_key") == "or-key-test"
+        finally:
+            del os.environ["OPENROUTER_API_KEY"]
+
+    def test_env_mcp_server_url_mapping(self):
+        os.environ["MCP_SERVER_URL"] = "http://localhost:9999"
+        try:
+            cm = ConfigManager()
+            cm.refresh()
+            assert cm.get("mcp_server_url") == "http://localhost:9999"
+        finally:
+            del os.environ["MCP_SERVER_URL"]
+
+
+class TestLoadFromFileExtended:
+    def test_settings_json_context_management_key_mapped(self, tmp_path):
+        config_file = tmp_path / "settings.json"
+        config_file.write_text(json.dumps({
+            "aura": {"context_management": {"enabled": False, "top_k": 5}, "model_name": "test"}
+        }))
+        cm = ConfigManager(config_file=str(config_file))
+        sm = cm.get("semantic_memory")
+        assert sm is not None
+        assert sm["top_k"] == 5
+
+    def test_flat_json_loaded_directly(self, tmp_path):
+        config_file = tmp_path / "flat.json"
+        config_file.write_text(json.dumps({"max_cycles": 8}))
+        cm = ConfigManager(config_file=str(config_file))
+        assert cm.get("max_cycles") == 8
+
+    def test_nested_aura_section_loaded(self, tmp_path):
+        config_file = tmp_path / "settings2.json"
+        config_file.write_text(json.dumps({"aura": {"max_iterations": 15}}))
+        cm = ConfigManager(config_file=str(config_file))
+        assert cm.get("max_iterations") == 15
+
+
+class TestFindAvailablePortExtended:
+    def test_returns_none_when_all_excluded(self):
+        cm = ConfigManager()
+        exclude = set(range(18600, 18605))
+        port = cm.find_available_port(start_port=18600, end_port=18604, exclude_ports=exclude)
+        assert port is None
+
+    def test_invalid_port_check_returns_false(self):
+        cm = ConfigManager()
+        assert cm.check_port_available(-1) is False
+        assert cm.check_port_available(70000) is False
+
+    def test_invalid_port_non_int_returns_false(self):
+        cm = ConfigManager()
+        assert cm.check_port_available("not_a_port") is False
+
+
+class TestValidateWithSchema:
+    def test_valid_config_no_errors(self):
+        cm = ConfigManager()
+        try:
+            cm._validate_with_schema({"model_name": "test", "max_iterations": 10})
+        except Exception:
+            pytest.fail("_validate_with_schema should not raise")
+
+    def test_invalid_config_does_not_raise(self):
+        cm = ConfigManager()
+        try:
+            cm._validate_with_schema({"max_iterations": -5})
+        except Exception:
+            pytest.fail("_validate_with_schema should not raise")
+
+
+class TestShowConfigExtended:
+    def test_show_config_has_all_default_keys(self):
+        cm = ConfigManager()
+        config = cm.show_config()
+        for key in DEFAULT_CONFIG:
+            assert key in config, f"Missing key: {key}"
+
+    def test_show_config_reflects_overrides(self):
+        cm = ConfigManager(overrides={"model_name": "override-model"})
+        config = cm.show_config()
+        assert config["model_name"] == "override-model"
+
+
+class TestValidatorEdgeCasesExtended:
+    def test_validate_bool_string_1(self):
+        ok, val, _ = _validate_bool("k", "1")
+        assert ok is True
+        assert val is True
+
+    def test_validate_bool_string_0(self):
+        ok, val, _ = _validate_bool("k", "0")
+        assert ok is True
+        assert val is False
+
+    def test_validate_bool_invalid_returns_false(self):
+        ok, _, reason = _validate_bool("k", "maybe")
+        assert ok is False
+
+    def test_validate_string_none_ok(self):
+        ok, val, _ = _validate_string("k", None)
+        assert ok is True
+        assert val is None
+
+    def test_validate_string_int_fails(self):
+        ok, _, _ = _validate_string("k", 42)
+        assert ok is False
+
+    def test_validate_float_range_below_min(self):
+        ok, _, _ = _validate_float_range("k", -1.0, 0.0, 100.0)
+        assert ok is False
+
+    def test_validate_float_range_above_max(self):
+        ok, _, _ = _validate_float_range("k", 101.0, 0.0, 100.0)
+        assert ok is False
+
+    def test_validate_float_range_non_numeric(self):
+        ok, _, _ = _validate_float_range("k", "not_a_float", 0.0, 100.0)
+        assert ok is False
+
+    def test_validate_float_range_boundary_min(self):
+        ok, val, _ = _validate_float_range("k", 0.0, 0.0, 100.0)
+        assert ok is True
+        assert val == 0.0
+
+    def test_validate_float_range_boundary_max(self):
+        ok, val, _ = _validate_float_range("k", 100.0, 0.0, 100.0)
+        assert ok is True
+        assert val == 100.0
+
+    def test_validate_positive_int_string_coercion(self):
+        ok, val, _ = _validate_positive_int("k", "10")
+        assert ok is True
+        assert val == 10
+
+
+class TestConfigManagerGetWithValidation:
+    def test_get_reliability_threshold_validated(self):
+        cm = ConfigManager()
+        val = cm.get("reliability_threshold")
+        assert isinstance(val, float)
+        assert 0.0 <= val <= 100.0
+
+    def test_get_llm_timeout_is_positive_int(self):
+        cm = ConfigManager()
+        val = cm.get("llm_timeout")
+        assert isinstance(val, int)
+        assert val > 0
+
+    def test_get_dry_run_is_bool(self):
+        cm = ConfigManager()
+        val = cm.get("dry_run")
+        assert isinstance(val, bool)
+
+    def test_get_model_name_is_str_or_none(self):
+        cm = ConfigManager()
+        val = cm.get("model_name")
+        assert val is None or isinstance(val, str)
+
+
+class TestKeyValidatorsRegistry:
+    def test_all_validators_are_callable(self):
+        for key, validator in _KEY_VALIDATORS.items():
+            assert callable(validator)
+
+    def test_validators_return_three_tuple(self):
+        for key, validator in list(_KEY_VALIDATORS.items())[:5]:
+            default = DEFAULT_CONFIG.get(key)
+            if default is None:
+                default = "test"
+            result = validator(key, default)
+            assert len(result) == 3

--- a/tests/test_context_graph_extended.py
+++ b/tests/test_context_graph_extended.py
@@ -1,0 +1,775 @@
+"""Extended unit tests for core/context_graph.py — ContextGraph.
+
+Covers graph operations, caching, batch queries, and graph analysis not in main test file.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.context_graph import ContextGraph, _CacheEntry, _CACHE_TTL_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Cache Entry Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCacheEntry:
+    """Test cache entry TTL behavior."""
+
+    def test_cache_entry_stores_value(self):
+        """Verify cache entry stores value."""
+        entry = _CacheEntry("test_value")
+        assert entry.value == "test_value"
+
+    def test_cache_entry_records_timestamp(self):
+        """Verify cache entry records creation timestamp."""
+        entry = _CacheEntry("test")
+        assert entry.timestamp > 0
+        assert isinstance(entry.timestamp, float)
+
+    def test_cache_entry_is_not_expired_immediately(self):
+        """Verify newly created entry is not expired."""
+        entry = _CacheEntry("test")
+        assert entry.is_expired() is False
+
+    def test_cache_entry_expires_after_ttl(self):
+        """Verify entry expires after TTL."""
+        entry = _CacheEntry("test")
+        entry.timestamp = time.time() - (_CACHE_TTL_SECONDS + 1)
+        
+        assert entry.is_expired() is True
+
+    def test_cache_entry_custom_ttl(self):
+        """Verify custom TTL is respected."""
+        entry = _CacheEntry("test")
+        entry.timestamp = time.time() - 10
+        
+        assert entry.is_expired(ttl=5) is True
+        assert entry.is_expired(ttl=15) is False
+
+
+# ---------------------------------------------------------------------------
+# Database Initialization
+# ---------------------------------------------------------------------------
+
+
+class TestContextGraphInit:
+    """Test ContextGraph initialization."""
+
+    def test_context_graph_creates_db(self):
+        """Verify database is created on initialization."""
+        with tempfile.TemporaryDirectory() as td:
+            db_path = Path(td) / "test.db"
+            graph = ContextGraph(db_path=db_path)
+            
+            assert db_path.exists()
+
+    def test_context_graph_uses_default_path_if_none(self):
+        """Verify default path is used when not specified."""
+        graph = ContextGraph()
+        # Should not raise
+        assert graph._db_path is not None
+
+    def test_context_graph_caching_enabled_by_default(self):
+        """Verify caching is enabled by default."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            assert graph._enable_caching is True
+
+    def test_context_graph_caching_can_be_disabled(self):
+        """Verify caching can be disabled."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(
+                db_path=Path(td) / "test.db",
+                enable_caching=False
+            )
+            assert graph._enable_caching is False
+
+    def test_context_graph_cache_initialized_empty(self):
+        """Verify cache starts empty."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            assert len(graph._cache) == 0
+
+    def test_context_graph_cache_stats_initialized(self):
+        """Verify cache statistics start at zero."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            assert graph._cache_hits == 0
+            assert graph._cache_misses == 0
+
+
+# ---------------------------------------------------------------------------
+# Caching Layer
+# ---------------------------------------------------------------------------
+
+
+class TestCachingLayer:
+    """Test cache operations."""
+
+    def test_get_from_cache_returns_none_when_disabled(self):
+        """Verify cache returns None when disabled."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(
+                db_path=Path(td) / "test.db",
+                enable_caching=False
+            )
+            result = graph._get_from_cache("test_key")
+            assert result is None
+
+    def test_get_from_cache_miss(self):
+        """Verify cache miss returns None."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            result = graph._get_from_cache("nonexistent")
+            
+            assert result is None
+            assert graph._cache_misses == 1
+
+    def test_get_from_cache_hit(self):
+        """Verify cache hit returns value."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            graph._cache["key1"] = _CacheEntry("value1")
+            
+            result = graph._get_from_cache("key1")
+            
+            assert result == "value1"
+            assert graph._cache_hits == 1
+
+    def test_set_in_cache_when_disabled(self):
+        """Verify set_in_cache is no-op when disabled."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(
+                db_path=Path(td) / "test.db",
+                enable_caching=False
+            )
+            graph._set_in_cache("key", "value")
+            
+            assert len(graph._cache) == 0
+
+    def test_set_in_cache_stores_value(self):
+        """Verify set_in_cache stores value."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            graph._set_in_cache("key", "value")
+            
+            assert graph._get_from_cache("key") == "value"
+
+    def test_invalidate_cache_clears_all(self):
+        """Verify cache can be fully cleared."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            graph._cache["key1"] = _CacheEntry("value1")
+            graph._cache["key2"] = _CacheEntry("value2")
+            
+            graph._invalidate_cache()
+            
+            assert len(graph._cache) == 0
+
+    def test_invalidate_cache_by_prefix(self):
+        """Verify cache can be invalidated by prefix."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            graph._cache["node:1"] = _CacheEntry("v1")
+            graph._cache["node:2"] = _CacheEntry("v2")
+            graph._cache["edge:1"] = _CacheEntry("v3")
+            
+            graph._invalidate_cache(prefix="node:")
+            
+            assert "node:1" not in graph._cache
+            assert "node:2" not in graph._cache
+            assert "edge:1" in graph._cache
+
+    def test_set_in_cache_evicts_when_full(self):
+        """Verify LRU eviction when cache is full."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            # Fill cache
+            for i in range(1024):
+                graph._cache[f"key_{i}"] = _CacheEntry(f"value_{i}")
+            
+            original_size = len(graph._cache)
+            
+            # Add one more (should trigger eviction)
+            graph._set_in_cache("overflow", "value")
+            
+            # Should have evicted ~10% (102 entries)
+            assert len(graph._cache) < original_size
+
+    def test_get_cache_stats(self):
+        """Verify cache statistics are calculated correctly."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            graph._cache["key1"] = _CacheEntry("value1")
+            
+            # Generate hits and misses
+            graph._get_from_cache("key1")  # hit
+            graph._get_from_cache("key1")  # hit
+            graph._get_from_cache("missing")  # miss
+            
+            stats = graph.get_cache_stats()
+            
+            assert stats["hits"] == 2
+            assert stats["misses"] == 1
+            assert stats["size"] == 1
+            assert stats["hit_rate_percent"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Public API: add_edge
+# ---------------------------------------------------------------------------
+
+
+class TestAddEdge:
+    """Test public edge addition API."""
+
+    def test_add_edge_creates_edge(self):
+        """Verify edge can be created via public API."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("core/a.py", "core/b.py", "depends_on", weight=1.5)
+            
+            # Verify nodes were created
+            nodes = graph.get_nodes_batch([f"file:core/a.py", f"file:core/b.py"])
+            assert len(nodes) == 2
+
+    def test_add_edge_creates_file_nodes(self):
+        """Verify file nodes are created automatically."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src.py", "dst.py", "uses")
+            
+            # Check nodes exist
+            src_node = graph.get_node(f"file:src.py")
+            dst_node = graph.get_node(f"file:dst.py")
+            
+            assert src_node is not None
+            assert dst_node is not None
+            assert src_node["type"] == "file"
+            assert dst_node["type"] == "file"
+
+    def test_add_edge_with_default_weight(self):
+        """Verify default weight is 1.0."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            # Verify edge was created (no error)
+            edges = graph.get_edges_batch(
+                src_ids=[f"file:a.py"]
+            )
+            assert len(edges) > 0
+
+    def test_add_edge_with_custom_weight(self):
+        """Verify custom weight is stored."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses", weight=2.5)
+            
+            edges = graph.get_edges_batch(src_ids=[f"file:a.py"])
+            assert len(edges) > 0
+
+
+# ---------------------------------------------------------------------------
+# Node Operations
+# ---------------------------------------------------------------------------
+
+
+class TestNodeOperations:
+    """Test node operations via batch APIs."""
+
+    def test_get_node_returns_none_for_nonexistent(self):
+        """Verify get_node returns None for nonexistent node."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            node = graph.get_node("nonexistent_id")
+            
+            assert node is None
+
+    def test_get_nodes_batch_retrieves_multiple(self):
+        """Verify batch node retrieval."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            # Create nodes via edges (public API)
+            graph.add_edge("a.py", "b.py", "uses")
+            graph.add_edge("c.py", "d.py", "uses")
+            
+            # Retrieve in batch
+            nodes = graph.get_nodes_batch([f"file:a.py", f"file:b.py"])
+            
+            assert len(nodes) >= 0
+
+    def test_get_nodes_batch_empty_list(self):
+        """Verify empty list returns empty dict."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            nodes = graph.get_nodes_batch([])
+            
+            assert nodes == {}
+
+    def test_get_nodes_batch_uses_cache(self):
+        """Verify batch retrieval uses cache."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            # Create a node
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            # First call
+            nodes1 = graph.get_nodes_batch([f"file:a.py"])
+            hits_before = graph._cache_hits
+            
+            # Second call (should hit cache)
+            nodes2 = graph.get_nodes_batch([f"file:a.py"])
+            hits_after = graph._cache_hits
+            
+            assert hits_after >= hits_before
+
+
+# ---------------------------------------------------------------------------
+# Edge Operations
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeOperations:
+    """Test edge operations."""
+
+    def test_get_edge_returns_none_for_nonexistent(self):
+        """Verify get_edge returns None for nonexistent edge."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            edge = graph.get_edge("nonexistent")
+            
+            assert edge is None
+
+    def test_get_edges_batch_by_src(self):
+        """Verify batch edge retrieval by source."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src.py", "dst1.py", "uses")
+            graph.add_edge("src.py", "dst2.py", "uses")
+            
+            edges = graph.get_edges_batch(src_ids=[f"file:src.py"])
+            
+            assert len(edges) >= 2
+
+    def test_get_edges_batch_by_dst(self):
+        """Verify batch edge retrieval by destination."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src1.py", "dst.py", "uses")
+            graph.add_edge("src2.py", "dst.py", "uses")
+            
+            edges = graph.get_edges_batch(dst_ids=[f"file:dst.py"])
+            
+            assert len(edges) >= 2
+
+    def test_get_edges_batch_by_relation(self):
+        """Verify batch edge retrieval by relation type."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            graph.add_edge("a.py", "c.py", "related_to")
+            
+            edges = graph.get_edges_batch(relations=["uses"])
+            
+            assert any(e["relation"] == "uses" for e in edges)
+
+    def test_get_edges_batch_combined_filters(self):
+        """Verify batch edge retrieval with multiple filters."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src.py", "dst1.py", "uses")
+            graph.add_edge("src.py", "dst2.py", "related_to")
+            
+            edges = graph.get_edges_batch(src_ids=[f"file:src.py"], relations=["uses"])
+            
+            # Should only have 'uses' edges from src
+            for edge in edges:
+                if edge["src_id"] == f"file:src.py":
+                    assert edge["relation"] == "uses"
+
+
+# ---------------------------------------------------------------------------
+# Neighborhood Operations
+# ---------------------------------------------------------------------------
+
+
+class TestNeighborhoodOperations:
+    """Test node neighborhood queries."""
+
+    def test_get_neighbors_batch_outgoing(self):
+        """Verify outgoing neighbors retrieval."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src.py", "dst1.py", "uses")
+            graph.add_edge("src.py", "dst2.py", "uses")
+            
+            neighbors = graph.get_neighbors_batch([f"file:src.py"], direction="outgoing")
+            
+            assert f"file:src.py" in neighbors
+
+    def test_get_neighbors_batch_incoming(self):
+        """Verify incoming neighbors retrieval."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src1.py", "dst.py", "uses")
+            graph.add_edge("src2.py", "dst.py", "uses")
+            
+            neighbors = graph.get_neighbors_batch([f"file:dst.py"], direction="incoming")
+            
+            assert f"file:dst.py" in neighbors
+
+    def test_get_neighbors_batch_both(self):
+        """Verify bidirectional neighbors retrieval."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("dep1.py", "node.py", "uses")
+            graph.add_edge("dep2.py", "node.py", "uses")
+            graph.add_edge("node.py", "user.py", "uses")
+            
+            neighbors = graph.get_neighbors_batch([f"file:node.py"], direction="both")
+            
+            assert f"file:node.py" in neighbors
+
+    def test_get_neighbors_batch_filtered_by_relation(self):
+        """Verify neighbors can be filtered by relation type."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("src.py", "uses_dst.py", "uses")
+            graph.add_edge("src.py", "related_dst.py", "related_to")
+            
+            neighbors = graph.get_neighbors_batch(
+                [f"file:src.py"],
+                relation="uses",
+                direction="outgoing"
+            )
+            
+            assert f"file:src.py" in neighbors
+
+
+# ---------------------------------------------------------------------------
+# Eager Loading
+# ---------------------------------------------------------------------------
+
+
+class TestEagerLoading:
+    """Test eager loading of nodes and edges."""
+
+    def test_get_nodes_with_edges_retrieves_both(self):
+        """Verify eager loading retrieves nodes and edges."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            nodes, edges = graph.get_nodes_with_edges([f"file:a.py", f"file:b.py"])
+            
+            assert len(nodes) >= 0
+            assert isinstance(edges, list)
+
+    def test_get_nodes_with_edges_excludes_incoming(self):
+        """Verify incoming edges can be excluded."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            nodes, edges = graph.get_nodes_with_edges(
+                [f"file:a.py", f"file:b.py"],
+                include_incoming=False
+            )
+            
+            assert isinstance(edges, list)
+
+    def test_get_nodes_with_edges_excludes_outgoing(self):
+        """Verify outgoing edges can be excluded."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            nodes, edges = graph.get_nodes_with_edges(
+                [f"file:a.py", f"file:b.py"],
+                include_outgoing=False
+            )
+            
+            assert isinstance(edges, list)
+
+
+# ---------------------------------------------------------------------------
+# Graph Analysis
+# ---------------------------------------------------------------------------
+
+
+class TestGraphAnalysis:
+    """Test graph analysis methods."""
+
+    def test_goals_touching_file(self):
+        """Verify goal query for a file."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            goals = graph.goals_touching_file("core/main.py")
+            
+            assert isinstance(goals, list)
+
+    def test_query_similar_resolutions(self):
+        """Verify similar resolution query."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            similar = graph.query_similar_resolutions("core/orchestrator.py")
+            
+            assert isinstance(similar, list)
+
+    def test_best_skills_for_goal_type(self):
+        """Verify best skills query for goal type."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            skills = graph.best_skills_for_goal_type("bug_fix")
+            
+            assert isinstance(skills, list)
+
+    def test_weaknesses_for_goal_type(self):
+        """Verify weaknesses query for goal type."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            weaknesses = graph.weaknesses_for_goal_type("refactor")
+            
+            assert isinstance(weaknesses, list)
+
+    def test_file_failure_count(self):
+        """Verify file failure count query."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            count = graph.file_failure_count("test.py")
+            
+            assert isinstance(count, int)
+            assert count >= 0
+
+    def test_find_bottleneck_files(self):
+        """Verify bottleneck file detection."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            bottlenecks = graph.find_bottleneck_files()
+            
+            assert isinstance(bottlenecks, list)
+
+    def test_find_circular_dependencies(self):
+        """Verify circular dependency detection."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            cycles = graph.find_circular_dependencies()
+            
+            assert isinstance(cycles, list)
+
+    def test_graph_summary(self):
+        """Verify graph summary generation."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            summary = graph.graph_summary()
+            
+            assert isinstance(summary, dict)
+            assert "nodes" in summary or "edges" in summary
+
+
+# ---------------------------------------------------------------------------
+# NetworkX Integration
+# ---------------------------------------------------------------------------
+
+
+class TestNetworkXIntegration:
+    """Test NetworkX graph export."""
+
+    def test_get_nx_graph(self):
+        """Verify NetworkX graph export."""
+        pytest.importorskip("networkx")
+        
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            nx_graph = graph.get_nx_graph()
+            
+            assert nx_graph is not None
+
+    def test_get_nx_graph_with_filter(self):
+        """Verify NetworkX graph creation."""
+        pytest.importorskip("networkx")
+        
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            
+            # get_nx_graph takes relations parameter, not node_types
+            nx_graph = graph.get_nx_graph(relations=["uses"])
+            
+            assert nx_graph is not None
+
+
+# ---------------------------------------------------------------------------
+# Cycle Updates
+# ---------------------------------------------------------------------------
+
+
+class TestCycleUpdates:
+    """Test updating graph from cycle data."""
+
+    def test_update_from_cycle(self):
+        """Verify cycle data integration."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            cycle_entry = {
+                "cycle_id": "cycle_1",
+                "goal": "implement feature",
+                "files_changed": ["core/main.py", "core/utils.py"],
+                "skills_used": ["refactor", "test_writer"],
+            }
+            
+            # Should not raise
+            graph.update_from_cycle(cycle_entry)
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_empty_node_id(self):
+        """Verify handling of empty node ID."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            node = graph.get_node("")
+            assert node is None
+
+    def test_very_long_label(self):
+        """Verify handling of very long label."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            long_label = "x" * 10000
+            graph.add_edge(long_label, "b.py", "uses")
+            
+            # Should not raise
+
+    def test_special_characters_in_labels(self):
+        """Verify handling of special characters in labels."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            special = "test!@#$%^&*().py"
+            graph.add_edge(special, "other.py", "uses")
+            
+            # Should not raise
+
+    def test_negative_weight_on_edge(self):
+        """Verify handling of negative edge weights."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses", weight=-1.0)
+            
+            edges = graph.get_edges_batch(src_ids=[f"file:a.py"])
+            assert len(edges) > 0
+
+    def test_zero_weight_on_edge(self):
+        """Verify handling of zero edge weight."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses", weight=0.0)
+            
+            edges = graph.get_edges_batch(src_ids=[f"file:a.py"])
+            assert len(edges) > 0
+
+    def test_very_large_graph(self):
+        """Verify handling of large graph."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            # Create 50 edges
+            for i in range(50):
+                graph.add_edge(f"file_{i}.py", f"file_{i+1}.py", "uses")
+            
+            # Retrieve in batch
+            node_ids = [f"file:file_{i}.py" for i in range(50)]
+            nodes = graph.get_nodes_batch(node_ids)
+            
+            assert len(nodes) > 0
+
+    def test_duplicate_edge_handling(self):
+        """Verify duplicate edge handling."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            # Add same edge twice with different weights
+            graph.add_edge("a.py", "b.py", "uses", weight=1.0)
+            graph.add_edge("a.py", "b.py", "uses", weight=2.0)
+            
+            # Should not raise - implementation handles upsert
+
+
+# ---------------------------------------------------------------------------
+# Batch Traversal
+# ---------------------------------------------------------------------------
+
+
+class TestBatchTraversal:
+    """Test batch graph traversal."""
+
+    def test_traverse_batched_basic(self):
+        """Verify batch traversal execution."""
+        with tempfile.TemporaryDirectory() as td:
+            graph = ContextGraph(db_path=Path(td) / "test.db")
+            
+            graph.add_edge("a.py", "b.py", "uses")
+            graph.add_edge("b.py", "c.py", "uses")
+            
+            # Traverse from a node (uses start_node_ids parameter)
+            results = graph.traverse_batched(
+                start_node_ids=[f"file:a.py"],
+                max_depth=2,
+                direction="outgoing"
+            )
+            
+            assert isinstance(results, dict)

--- a/tests/test_dispatch_extended.py
+++ b/tests/test_dispatch_extended.py
@@ -1,0 +1,2248 @@
+"""Extended coverage tests for aura_cli/dispatch.py — Sprint 9."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+
+os.environ.setdefault("AURA_SKIP_CHDIR", "1")
+os.environ.setdefault("AURA_TEST_MODE", "1")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs):
+    defaults = dict(
+        action=None,
+        dry_run=False,
+        decompose=False,
+        model=None,
+        anthropic_api_key=None,
+        beads=False,
+        no_beads=False,
+        beads_required=False,
+        beads_optional=False,
+        json=False,
+        help_topics=None,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _make_ctx(args=None, *, project_root=None, runtime=None, parsed=None):
+    from aura_cli.dispatch import DispatchContext
+
+    ctx = DispatchContext(
+        parsed=parsed or SimpleNamespace(warning_records=[], warnings=[]),
+        project_root=project_root or Path("/fake/proj"),
+        runtime_factory=MagicMock(),
+        args=args or _make_args(),
+    )
+    if runtime is not None:
+        ctx.runtime = runtime
+    return ctx
+
+
+def _fake_runtime(**overrides):
+    rt = {
+        "goal_queue": MagicMock(),
+        "goal_archive": MagicMock(),
+        "orchestrator": MagicMock(),
+        "debugger": MagicMock(),
+        "planner": MagicMock(),
+        "brain": MagicMock(),
+        "model_adapter": MagicMock(),
+        "memory_store": MagicMock(),
+        "vector_store": MagicMock(),
+        "memory_persistence_path": "/fake/memory.db",
+    }
+    rt.update(overrides)
+    return rt
+
+
+# ---------------------------------------------------------------------------
+# _prepare_runtime_context — additional branches
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareRuntimeContextExtra:
+    def setup_method(self):
+        from aura_cli.dispatch import DispatchContext
+
+        self.DispatchContext = DispatchContext
+
+    def _make_ctx_for_prep(self, args):
+        ctx = self.DispatchContext(
+            parsed=SimpleNamespace(action=getattr(args, "action", None), warning_records=[], warnings=[]),
+            project_root=Path("/fake/proj"),
+            runtime_factory=MagicMock(return_value=_fake_runtime()),
+            args=args,
+        )
+        return ctx
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._check_project_writability", return_value=True)
+    @patch("aura_cli.dispatch.log_json")
+    def test_model_override_is_passed(self, _log, _writable, _compat):
+        args = _make_args(model="claude-3", action="goal_once")
+        ctx = self._make_ctx_for_prep(args)
+        from aura_cli.dispatch import _prepare_runtime_context
+
+        rc = _prepare_runtime_context(ctx)
+        assert rc is None
+        call_overrides = ctx.runtime_factory.call_args[1]["overrides"]
+        assert call_overrides["model_name"] == "claude-3"
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._check_project_writability", return_value=True)
+    @patch("aura_cli.dispatch.log_json")
+    def test_anthropic_api_key_override(self, _log, _writable, _compat):
+        args = _make_args(anthropic_api_key="sk-test", action="goal_once")
+        ctx = self._make_ctx_for_prep(args)
+        from aura_cli.dispatch import _prepare_runtime_context
+
+        rc = _prepare_runtime_context(ctx)
+        assert rc is None
+        call_overrides = ctx.runtime_factory.call_args[1]["overrides"]
+        assert call_overrides["anthropic_api_key"] == "sk-test"
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._check_project_writability", return_value=True)
+    @patch("aura_cli.dispatch.log_json")
+    def test_no_overrides_calls_factory_with_none(self, _log, _writable, _compat):
+        args = _make_args(action="goal_once")
+        ctx = self._make_ctx_for_prep(args)
+        from aura_cli.dispatch import _prepare_runtime_context
+
+        rc = _prepare_runtime_context(ctx)
+        assert rc is None
+        call_kwargs = ctx.runtime_factory.call_args[1]
+        assert call_kwargs["overrides"] is None
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._check_project_writability", return_value=True)
+    @patch("aura_cli.dispatch.log_json")
+    def test_runtime_mode_queue_for_goal_status(self, _log, _writable, _compat):
+        args = _make_args(action="goal_status")
+        ctx = self._make_ctx_for_prep(args)
+        from aura_cli.dispatch import _prepare_runtime_context
+
+        _prepare_runtime_context(ctx)
+        overrides = ctx.runtime_factory.call_args[1]["overrides"]
+        assert overrides["runtime_mode"] == "queue"
+
+
+# ---------------------------------------------------------------------------
+# _handle_help_dispatch — additional branch: ValueError no JSON
+# ---------------------------------------------------------------------------
+
+
+class TestHelpDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.render_help", side_effect=ValueError("bad topic"))
+    def test_value_error_no_json_prints_to_stderr(self, _render, _compat, capsys):
+        from aura_cli.dispatch import _handle_help_dispatch
+
+        ctx = _make_ctx(args=_make_args(json=False, help_topics="bad"))
+        rc = _handle_help_dispatch(ctx)
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "Error: bad topic" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _handle_show_config_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestShowConfigDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_prints_json(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_show_config_dispatch
+
+        mock_config.show_config.return_value = {"key": "val"}
+        ctx = _make_ctx()
+        rc = _handle_show_config_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# _handle_config_set_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSetDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_plain_key_updates_config(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_config_set_dispatch
+
+        args = _make_args(config_key="max_cycles", config_value="10")
+        ctx = _make_ctx(args=args)
+        rc = _handle_config_set_dispatch(ctx)
+        assert rc == 0
+        mock_config.update_config.assert_called_once_with({"max_cycles": "10"})
+        assert "max_cycles" in capsys.readouterr().out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_model_dot_key_routes_to_model_routing(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_config_set_dispatch
+
+        args = _make_args(config_key="model.plan", config_value="gpt-4")
+        ctx = _make_ctx(args=args)
+        rc = _handle_config_set_dispatch(ctx)
+        assert rc == 0
+        mock_config.update_config.assert_called_once_with({"model_routing": {"plan": "gpt-4"}})
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_exception_returns_one(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_config_set_dispatch
+
+        mock_config.update_config.side_effect = RuntimeError("disk full")
+        args = _make_args(config_key="x", config_value="y")
+        ctx = _make_ctx(args=args)
+        rc = _handle_config_set_dispatch(ctx)
+        assert rc == 1
+        assert "disk full" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _handle_doctor_dispatch & _handle_readiness_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSimpleHandlersExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_doctor")
+    def test_doctor_dispatch(self, mock_doctor, _compat):
+        from aura_cli.dispatch import _handle_doctor_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_doctor_dispatch(ctx)
+        assert rc == 0
+        mock_doctor.assert_called_once_with(ctx.project_root)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_readiness")
+    def test_readiness_dispatch(self, mock_readiness, _compat):
+        from aura_cli.dispatch import _handle_readiness_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_readiness_dispatch(ctx)
+        assert rc == 0
+        mock_readiness.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_bootstrap_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_calls_interactive_bootstrap(self, mock_config, _compat):
+        from aura_cli.dispatch import _handle_bootstrap_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_bootstrap_dispatch(ctx)
+        assert rc == 0
+        mock_config.interactive_bootstrap.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_memory_search_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMemorySearchDispatch:
+    def _make_hit(self, score=0.9, source_ref="file.py", content="content"):
+        h = MagicMock()
+        h.score = score
+        h.source_ref = source_ref
+        h.content = content
+        return h
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_hits_prints_message(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_memory_search_dispatch
+
+        rt = _fake_runtime()
+        rt["vector_store"] = MagicMock()
+        rt["vector_store"].search.return_value = []
+        args = _make_args(query="test", limit=5, json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+
+        with patch("aura_cli.dispatch.RetrievalQuery", create=True) as _rq:
+            # patch the local import
+            with patch("core.memory_types.RetrievalQuery") as mock_rq:
+                mock_rq.return_value = MagicMock()
+                rc = _handle_memory_search_dispatch(ctx)
+
+        assert rc == 0
+        assert "No results found" in capsys.readouterr().out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_hits_are_printed(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_memory_search_dispatch
+
+        hit = self._make_hit(score=0.85, source_ref="src/foo.py", content="x" * 50)
+        rt = _fake_runtime()
+        rt["vector_store"] = MagicMock()
+        rt["vector_store"].search.return_value = [hit]
+        args = _make_args(query="foo", limit=5, json=False)
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+
+        with patch("core.memory_types.RetrievalQuery") as mock_rq:
+            mock_rq.return_value = MagicMock()
+            rc = _handle_memory_search_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "0.850" in out or "Score" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_json_mode_outputs_json(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_memory_search_dispatch
+
+        hit = self._make_hit(score=0.5, source_ref="a.py", content="hello world")
+        rt = _fake_runtime()
+        rt["vector_store"] = MagicMock()
+        rt["vector_store"].search.return_value = [hit]
+        args = _make_args(query="q", limit=3, json=True)
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+
+        with patch("core.memory_types.RetrievalQuery") as mock_rq:
+            mock_rq.return_value = MagicMock()
+            rc = _handle_memory_search_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "hits" in data
+        assert data["query"] == "q"
+
+
+# ---------------------------------------------------------------------------
+# _handle_memory_reindex_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryReindexDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_json_mode_returns_ok(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_memory_reindex_dispatch
+
+        rt = _fake_runtime()
+        mock_vs = MagicMock()
+        mock_vs.rebuild.return_value = {"embeddings_written": 10, "records_seen": 10}
+        rt["vector_store"] = mock_vs
+        mock_adapter = MagicMock()
+        mock_adapter.model_id.return_value = "text-embed"
+        mock_adapter.dimensions.return_value = 1536
+        rt["model_adapter"] = mock_adapter
+
+        args = _make_args(json=True)
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+
+        with patch("core.project_syncer.ProjectKnowledgeSyncer") as mock_syncer_cls:
+            mock_syncer = MagicMock()
+            mock_syncer.sync_all.return_value = {"files_processed": 5, "chunks_created": 10, "files_skipped": 1}
+            mock_syncer_cls.return_value = mock_syncer
+            rc = _handle_memory_reindex_dispatch(ctx)
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["status"] == "ok"
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_plain_mode_prints_summary(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_memory_reindex_dispatch
+
+        rt = _fake_runtime()
+        mock_vs = MagicMock()
+        mock_vs.rebuild.return_value = {"embeddings_written": 5, "records_seen": 7}
+        rt["vector_store"] = mock_vs
+        mock_adapter = MagicMock()
+        mock_adapter.model_id.return_value = "embed-v1"
+        mock_adapter.dimensions.return_value = 768
+        rt["model_adapter"] = mock_adapter
+
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+
+        with patch("core.project_syncer.ProjectKnowledgeSyncer") as mock_syncer_cls:
+            mock_syncer = MagicMock()
+            mock_syncer.sync_all.return_value = {"files_processed": 3, "chunks_created": 6, "files_skipped": 0}
+            mock_syncer_cls.return_value = mock_syncer
+            rc = _handle_memory_reindex_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "reindex complete" in out.lower() or "embed-v1" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_metrics_show_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsShowDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_data_prints_message(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_metrics_show_dispatch
+
+        rt = _fake_runtime()
+        rt["memory_store"] = MagicMock()
+        rt["memory_store"].read_log.return_value = []
+        rt["brain"] = MagicMock()
+        rt["brain"].recall_recent.return_value = []
+
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_metrics_show_dispatch(ctx)
+        assert rc == 0
+        assert "No metrics" in capsys.readouterr().out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_structured_summaries_json_mode(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_metrics_show_dispatch
+
+        rt = _fake_runtime()
+        log_entries = [
+            {
+                "cycle_summary": {
+                    "outcome": "SUCCESS",
+                    "duration_s": 3.5,
+                    "cycle_id": "abc123",
+                    "goal": "do something",
+                    "stop_reason": "done",
+                }
+            }
+        ]
+        rt["memory_store"] = MagicMock()
+        rt["memory_store"].read_log.return_value = log_entries
+
+        args = _make_args(json=True)
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+        rc = _handle_metrics_show_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["summary"]["successes"] == 1
+        assert out["summary"]["win_rate"] == 100.0
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_fallback_legacy_outcomes(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_metrics_show_dispatch
+
+        rt = _fake_runtime()
+        import time
+
+        ts = time.time()
+        raw_entry = f"outcome:id1 -> {json.dumps({'success': True, 'goal': 'legacy goal', 'started_at': ts - 2, 'completed_at': ts, 'cycle_id': 'leg1'})}"
+        rt["memory_store"] = MagicMock()
+        rt["memory_store"].read_log.return_value = []
+        rt["brain"] = MagicMock()
+        rt["brain"].recall_recent.return_value = [raw_entry]
+
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_metrics_show_dispatch(ctx)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "SUCCESS" in out or "100.0%" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_structured_summaries_plain_mode(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_metrics_show_dispatch
+
+        rt = _fake_runtime()
+        log_entries = [
+            {
+                "cycle_summary": {
+                    "outcome": "FAILED",
+                    "duration_s": 1.0,
+                    "cycle_id": "deadbeef",
+                    "goal": "a long goal name here",
+                    "stop_reason": "max_cycles",
+                }
+            }
+        ]
+        rt["memory_store"] = MagicMock()
+        rt["memory_store"].read_log.return_value = log_entries
+
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_metrics_show_dispatch(ctx)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "FAILED" in out or "0.0%" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_workflow_run_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowRunDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_calls_orchestrator_run_loop(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_workflow_run_dispatch
+
+        mock_config.get.return_value = 5
+        rt = _fake_runtime()
+        rt["orchestrator"].run_loop.return_value = {"stop_reason": "done", "history": ["a", "b"]}
+
+        args = _make_args(
+            workflow_goal="test workflow",
+            workflow_max_cycles=3,
+            max_cycles=None,
+            dry_run=False,
+        )
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+
+        with patch("core.operator_runtime.build_beads_runtime_metadata", return_value={}):
+            rc = _handle_workflow_run_dispatch(ctx)
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["goal"] == "test workflow"
+        assert out["stop_reason"] == "done"
+        assert out["cycles"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _handle_scaffold_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestScaffoldDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.ScaffolderAgent")
+    @patch("aura_cli.dispatch.Brain")
+    def test_plain_mode_prints_result(self, mock_brain, mock_scaff_cls, _compat, capsys):
+        from aura_cli.dispatch import _handle_scaffold_dispatch
+
+        mock_scaff = MagicMock()
+        mock_scaff.scaffold_project.return_value = "project scaffolded!"
+        mock_scaff_cls.return_value = mock_scaff
+
+        rt = _fake_runtime()
+        args = _make_args(scaffold="myapp", scaffold_desc="A test app", json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_scaffold_dispatch(ctx)
+        assert rc == 0
+        assert "project scaffolded!" in capsys.readouterr().out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.ScaffolderAgent")
+    @patch("aura_cli.dispatch.Brain")
+    def test_json_mode_prints_payload(self, mock_brain, mock_scaff_cls, _compat, capsys):
+        from aura_cli.dispatch import _handle_scaffold_dispatch
+
+        mock_scaff = MagicMock()
+        mock_scaff.scaffold_project.return_value = "ok"
+        mock_scaff_cls.return_value = mock_scaff
+
+        rt = _fake_runtime()
+        args = _make_args(scaffold="myapp2", scaffold_desc="desc", json=True)
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+        rc = _handle_scaffold_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["project_name"] == "myapp2"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_evolve_agents
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEvolveAgents:
+    def test_uses_orchestrator_agents_when_present(self):
+        from aura_cli.dispatch import _resolve_evolve_agents
+
+        brain = MagicMock()
+        model = MagicMock()
+        orchestrator = MagicMock()
+
+        act_agent = MagicMock()
+        critique_agent = MagicMock()
+        plan_agent = MagicMock()
+        orchestrator.agents = {
+            "act": act_agent,
+            "critique": critique_agent,
+            "plan": plan_agent,
+        }
+
+        planner, coder, critic = _resolve_evolve_agents(brain, model, orchestrator)
+        # They may be unwrapped via .agent attribute lookup, so just check we got something
+        assert planner is not None
+        assert coder is not None
+        assert critic is not None
+
+    @patch("aura_cli.dispatch.default_agents")
+    def test_falls_back_to_default_agents(self, mock_default):
+        from aura_cli.dispatch import _resolve_evolve_agents
+
+        brain = MagicMock()
+        model = MagicMock()
+        orchestrator = MagicMock()
+        orchestrator.agents = None
+
+        act = MagicMock()
+        act.agent = MagicMock()
+        critique = MagicMock()
+        critique.agent = MagicMock()
+        plan = MagicMock()
+        plan.agent = MagicMock()
+        mock_default.return_value = {"act": act, "critique": critique, "plan": plan}
+
+        planner, coder, critic = _resolve_evolve_agents(brain, model, orchestrator)
+        mock_default.assert_called_once_with(brain, model)
+
+    def test_resolves_missing_agents_via_handlers(self):
+        from aura_cli.dispatch import _resolve_evolve_agents
+
+        brain = MagicMock()
+        model = MagicMock()
+        orchestrator = MagicMock()
+        orchestrator.agents = {}  # no agents
+
+        mock_coder = MagicMock()
+        mock_critic = MagicMock()
+        mock_planner = MagicMock()
+
+        with (
+            patch("agents.handlers.coder._resolve_agent", return_value=mock_coder),
+            patch("agents.handlers.critic._resolve_agent", return_value=mock_critic),
+            patch("agents.handlers.planner._resolve_agent", return_value=mock_planner),
+            patch("aura_cli.dispatch.default_agents", return_value={}),
+        ):
+            planner, coder, critic = _resolve_evolve_agents(brain, model, orchestrator)
+
+        assert coder is mock_coder
+        assert critic is mock_critic
+        assert planner is mock_planner
+
+
+# ---------------------------------------------------------------------------
+# _handle_goal_status_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGoalStatusDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_status")
+    def test_plain_mode_calls_handle_status(self, mock_status, _compat):
+        from aura_cli.dispatch import _handle_goal_status_dispatch
+
+        rt = _fake_runtime()
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_goal_status_dispatch(ctx)
+        assert rc == 0
+        mock_status.assert_called_once()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_status")
+    def test_json_mode_wraps_with_warnings(self, mock_status, _compat):
+        from aura_cli.dispatch import _handle_goal_status_dispatch
+
+        mock_status.return_value = None
+        rt = _fake_runtime()
+        args = _make_args(json=True)
+        ctx = _make_ctx(args=args, runtime=rt, parsed=SimpleNamespace(warning_records=[], warnings=[]))
+        rc = _handle_goal_status_dispatch(ctx)
+        assert rc == 0
+        mock_status.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _maybe_add_goal
+# ---------------------------------------------------------------------------
+
+
+class TestMaybeAddGoal:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_no_add_goal_attr_is_noop(self, _log, _compat):
+        from aura_cli.dispatch import _maybe_add_goal
+
+        rt = _fake_runtime()
+        ctx = _make_ctx(args=_make_args(), runtime=rt)
+        _maybe_add_goal(ctx)
+        rt["goal_queue"].add.assert_not_called()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_adds_goal_to_queue(self, _log, _compat, capsys):
+        from aura_cli.dispatch import _maybe_add_goal
+
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = ["existing"]
+        args = _make_args(add_goal="my new goal", json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        _maybe_add_goal(ctx)
+        rt["goal_queue"].add.assert_called_once_with("my new goal")
+        out = capsys.readouterr().out
+        assert "Added goal" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_json_mode_suppresses_print(self, _log, _compat, capsys):
+        from aura_cli.dispatch import _maybe_add_goal
+
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = []
+        args = _make_args(add_goal="goal x", json=True)
+        ctx = _make_ctx(args=args, runtime=rt)
+        _maybe_add_goal(ctx)
+        out = capsys.readouterr().out
+        assert "Added goal" not in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_goal_once_dispatch — error branches
+# ---------------------------------------------------------------------------
+
+
+class TestGoalOnceDispatchErrors:
+    def _make_goal_once_ctx(self, **kwargs):
+        rt = _fake_runtime()
+        defaults = dict(
+            goal="do something",
+            max_cycles=3,
+            dry_run=False,
+            explain=False,
+            json=False,
+        )
+        defaults.update(kwargs)
+        args = _make_args(**defaults)
+        return _make_ctx(args=args, runtime=rt, parsed=SimpleNamespace(warning_records=[], warnings=[]))
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_apply_error_returns_exit_apply_error(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_once_dispatch
+        from aura_cli.exit_codes import EXIT_APPLY_ERROR
+
+        mock_config.get.return_value = 5
+        ctx = self._make_goal_once_ctx()
+
+        with patch("core.file_tools.OldCodeNotFoundError", Exception, create=True):
+            from core.file_tools import OldCodeNotFoundError
+
+            ctx.runtime["orchestrator"].run_loop.side_effect = OldCodeNotFoundError("apply failed")
+            with patch("aura_cli.dispatch.log_json"):
+                rc = _handle_goal_once_dispatch(ctx)
+
+        assert rc == EXIT_APPLY_ERROR
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_generic_exception_returns_exit_failure(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_once_dispatch
+        from aura_cli.exit_codes import EXIT_FAILURE
+
+        mock_config.get.return_value = 5
+        ctx = self._make_goal_once_ctx()
+        ctx.runtime["orchestrator"].run_loop.side_effect = Exception("unexpected")
+
+        with patch("aura_cli.dispatch.log_json"):
+            rc = _handle_goal_once_dispatch(ctx)
+
+        assert rc == EXIT_FAILURE
+        assert "Error" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_llm_error_returns_llm_exit_code(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_once_dispatch
+        from aura_cli.exit_codes import EXIT_LLM_ERROR
+
+        mock_config.get.return_value = 5
+        ctx = self._make_goal_once_ctx()
+
+        class AnthropicError(Exception):
+            pass
+
+        ctx.runtime["orchestrator"].run_loop.side_effect = AnthropicError("rate limit")
+
+        with patch("aura_cli.dispatch.log_json"):
+            rc = _handle_goal_once_dispatch(ctx)
+
+        assert rc == EXIT_LLM_ERROR
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_keyboard_interrupt_returns_cancelled(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_once_dispatch
+        from aura_cli.exit_codes import EXIT_CANCELLED
+
+        mock_config.get.return_value = 5
+        ctx = self._make_goal_once_ctx()
+        ctx.runtime["orchestrator"].run_loop.side_effect = KeyboardInterrupt()
+
+        rc = _handle_goal_once_dispatch(ctx)
+        assert rc == EXIT_CANCELLED
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_explain_flag_calls_format_decision_log(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_once_dispatch
+        from aura_cli.exit_codes import EXIT_SUCCESS
+
+        mock_config.get.return_value = 5
+        ctx = self._make_goal_once_ctx(explain=True)
+        ctx.runtime["orchestrator"].run_loop.return_value = {"history": ["step1"], "stop_reason": "done"}
+
+        with (
+            patch("aura_cli.dispatch.log_json"),
+            patch("core.explain.format_decision_log", return_value="decision log") as mock_fmt,
+            patch("core.operator_runtime.build_beads_runtime_metadata", return_value={}),
+        ):
+            rc = _handle_goal_once_dispatch(ctx)
+
+        assert rc == EXIT_SUCCESS
+        mock_fmt.assert_called_once_with(["step1"])
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_sandbox_error_returns_sandbox_exit_code(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_once_dispatch
+        from aura_cli.exit_codes import EXIT_SANDBOX_ERROR
+
+        mock_config.get.return_value = 5
+        ctx = self._make_goal_once_ctx()
+
+        class SandboxViolationError(Exception):
+            pass
+
+        ctx.runtime["orchestrator"].run_loop.side_effect = SandboxViolationError("sandbox blocked")
+
+        with patch("aura_cli.dispatch.log_json"):
+            rc = _handle_goal_once_dispatch(ctx)
+
+        assert rc == EXIT_SANDBOX_ERROR
+
+
+# ---------------------------------------------------------------------------
+# _handle_goal_run_dispatch — error branches
+# ---------------------------------------------------------------------------
+
+
+class TestGoalRunDispatchErrors:
+    def _make_run_ctx(self, **kwargs):
+        rt = _fake_runtime()
+        defaults = dict(
+            decompose=False,
+            resume=False,
+        )
+        defaults.update(kwargs)
+        args = _make_args(**defaults)
+        return _make_ctx(args=args, runtime=rt)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    def test_keyboard_interrupt_returns_cancelled(self, mock_loop, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_run_dispatch
+        from aura_cli.exit_codes import EXIT_CANCELLED
+
+        mock_loop.side_effect = KeyboardInterrupt()
+        ctx = self._make_run_ctx()
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = False
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_run_dispatch(ctx)
+
+        assert rc == EXIT_CANCELLED
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    def test_generic_exception_returns_failure(self, mock_loop, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_run_dispatch
+        from aura_cli.exit_codes import EXIT_FAILURE
+
+        mock_loop.side_effect = RuntimeError("unexpected")
+        ctx = self._make_run_ctx()
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = False
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_run_dispatch(ctx)
+
+        assert rc == EXIT_FAILURE
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    def test_llm_error_returns_llm_exit_code(self, mock_loop, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_run_dispatch
+        from aura_cli.exit_codes import EXIT_LLM_ERROR
+
+        class RateLimitError(Exception):
+            pass
+
+        mock_loop.side_effect = RateLimitError("rate limit")
+        ctx = self._make_run_ctx()
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = False
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_run_dispatch(ctx)
+
+        assert rc == EXIT_LLM_ERROR
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    def test_success_returns_zero(self, mock_loop, _compat):
+        from aura_cli.dispatch import _handle_goal_run_dispatch
+        from aura_cli.exit_codes import EXIT_SUCCESS
+
+        mock_loop.return_value = None
+        ctx = self._make_run_ctx()
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = False
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_run_dispatch(ctx)
+
+        assert rc == EXIT_SUCCESS
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    def test_resume_flag_prints_resuming_message(self, mock_loop, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_run_dispatch
+
+        mock_loop.return_value = None
+        ctx = self._make_run_ctx(resume=True)
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = True
+            mock_tracker.read.return_value = {"goal": "previous goal"}
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_run_dispatch(ctx)
+
+        out = capsys.readouterr().out
+        assert "Resuming" in out or "previous goal" in out
+        assert rc == 0
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    def test_interrupted_detected_warns(self, mock_loop, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_run_dispatch
+
+        mock_loop.return_value = None
+        ctx = self._make_run_ctx(resume=False)
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = True
+            mock_tracker.read.return_value = {"goal": "old goal"}
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_run_dispatch(ctx)
+
+        err = capsys.readouterr().err
+        assert "Interrupted" in err or "old goal" in err or "resume" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# _handle_goal_add_dispatch and _handle_goal_add_run_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGoalAddDispatches:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_goal_add_calls_maybe_add_goal(self, _log, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_add_dispatch
+
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = []
+        args = _make_args(add_goal="test goal")
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_goal_add_dispatch(ctx)
+        assert rc == 0
+        rt["goal_queue"].add.assert_called_once_with("test goal")
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.run_goals_loop")
+    @patch("aura_cli.dispatch.log_json")
+    def test_goal_add_run_adds_and_runs(self, _log, mock_loop, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_add_run_dispatch
+
+        mock_loop.return_value = None
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = []
+        args = _make_args(add_goal="run goal", decompose=False, resume=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.exists.return_value = False
+            mock_tracker_cls.return_value = mock_tracker
+            rc = _handle_goal_add_run_dispatch(ctx)
+
+        rt["goal_queue"].add.assert_called_once_with("run goal")
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# _handle_goal_resume_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestGoalResumeDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_record_prints_message(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_resume_dispatch
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.read.return_value = None
+            mock_tracker_cls.return_value = mock_tracker
+            ctx = _make_ctx(args=_make_args(run=False))
+            rc = _handle_goal_resume_dispatch(ctx)
+
+        assert rc == 0
+        assert "No interrupted" in capsys.readouterr().out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_found_goal_is_requeued(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_goal_resume_dispatch
+
+        rt = _fake_runtime()
+        rt["goal_queue"] = MagicMock()
+
+        with patch("core.in_flight_tracker.InFlightTracker") as mock_tracker_cls:
+            mock_tracker = MagicMock()
+            mock_tracker.read.return_value = {
+                "goal": "recover me",
+                "started_at": "2024-01-01",
+                "phase": "plan",
+                "cycle_limit": 3,
+            }
+            mock_tracker_cls.return_value = mock_tracker
+            args = _make_args(run=False)
+            ctx = _make_ctx(args=args, runtime=rt)
+            rc = _handle_goal_resume_dispatch(ctx)
+
+        assert rc == 0
+        rt["goal_queue"].prepend_batch.assert_called_once_with(["recover me"])
+        out = capsys.readouterr().out
+        assert "recover me" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_credentials_*_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialsDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_migrate_credentials")
+    @patch("aura_cli.dispatch.config")
+    def test_migrate_calls_handler(self, mock_config, mock_migrate, _compat):
+        from aura_cli.dispatch import _handle_credentials_migrate_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_credentials_migrate_dispatch(ctx)
+        assert rc == 0
+        mock_migrate.assert_called_once_with(ctx.args, mock_config)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_secure_store")
+    @patch("aura_cli.dispatch.config")
+    def test_store_calls_handler(self, mock_config, mock_store, _compat):
+        from aura_cli.dispatch import _handle_credentials_store_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_credentials_store_dispatch(ctx)
+        assert rc == 0
+        mock_store.assert_called_once_with(ctx.args, mock_config)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_secure_delete")
+    @patch("aura_cli.dispatch.config")
+    def test_delete_calls_handler(self, mock_config, mock_delete, _compat):
+        from aura_cli.dispatch import _handle_credentials_delete_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_credentials_delete_dispatch(ctx)
+        assert rc == 0
+        mock_delete.assert_called_once_with(ctx.args, mock_config)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_status_plain_mode(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_credentials_status_dispatch
+
+        mock_config.get_credential_store_info.return_value = {
+            "app_name": "AURA",
+            "keyring_available": True,
+            "fallback_available": True,
+            "fallback_path": "/path/creds",
+            "fallback_exists": False,
+            "stored_keys_count": 2,
+        }
+        mock_config.secure_retrieve_credential.return_value = None
+
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args)
+        rc = _handle_credentials_status_dispatch(ctx)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "AURA" in out or "Credential" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.config")
+    def test_status_json_mode(self, mock_config, _compat, capsys):
+        from aura_cli.dispatch import _handle_credentials_status_dispatch
+
+        store_info = {
+            "app_name": "AURA",
+            "keyring_available": False,
+            "fallback_available": True,
+            "fallback_path": "/path/creds",
+            "fallback_exists": True,
+            "stored_keys_count": 1,
+        }
+        mock_config.get_credential_store_info.return_value = store_info
+
+        args = _make_args(json=True)
+        ctx = _make_ctx(
+            args=args,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+        rc = _handle_credentials_status_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["app_name"] == "AURA"
+
+
+# ---------------------------------------------------------------------------
+# _handle_mcp_status_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMcpStatusDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._run_async_safely")
+    def test_json_mode_returns_servers(self, mock_async, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_status_dispatch
+
+        mock_async.return_value = [{"name": "skills", "status": "healthy", "health_data": {}}]
+
+        with (
+            patch("core.mcp_health.get_health_summary", return_value={"healthy_count": 1, "total_servers": 1, "all_healthy": True}),
+            patch("core.mcp_registry.list_registered_services", return_value=[{"config_name": "skills", "url": "http://localhost:8080"}]),
+        ):
+            args = _make_args(json=True)
+            ctx = _make_ctx(
+                args=args,
+                parsed=SimpleNamespace(warning_records=[], warnings=[]),
+            )
+            rc = _handle_mcp_status_dispatch(ctx)
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert "servers" in out
+        assert "summary" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._run_async_safely")
+    def test_plain_mode_no_rich_falls_back(self, mock_async, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_status_dispatch
+
+        mock_async.return_value = [{"name": "dev_tools", "status": "offline", "health_data": {}}]
+
+        with (
+            patch("core.mcp_health.get_health_summary", return_value={"healthy_count": 0, "total_servers": 1, "all_healthy": False}),
+            patch("core.mcp_registry.list_registered_services", return_value=[]),
+            patch.dict("sys.modules", {"rich": None, "rich.console": None, "rich.table": None, "rich.box": None}),
+        ):
+            args = _make_args(json=False)
+            ctx = _make_ctx(args=args)
+            rc = _handle_mcp_status_dispatch(ctx)
+
+        # Returns 1 when not all_healthy
+        assert rc in (0, 1)
+
+
+# ---------------------------------------------------------------------------
+# _handle_mcp_restart_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMcpRestartDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_server_name_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_restart_dispatch
+
+        args = _make_args(mcp_server=None)
+        ctx = _make_ctx(args=args)
+        rc = _handle_mcp_restart_dispatch(ctx)
+        assert rc == 1
+        assert "required" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._run_async_safely")
+    def test_unknown_server_returns_one(self, mock_async, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_restart_dispatch
+
+        with patch("core.mcp_registry.get_registered_service", side_effect=KeyError("unknown")):
+            args = _make_args(mcp_server="unknown_server")
+            ctx = _make_ctx(args=args)
+            rc = _handle_mcp_restart_dispatch(ctx)
+
+        assert rc == 1
+        assert "unknown" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._run_async_safely")
+    def test_healthy_server_json_returns_zero(self, mock_async, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_restart_dispatch
+
+        mock_async.return_value = {"status": "healthy"}
+
+        with patch("core.mcp_registry.get_registered_service", return_value={"url": "http://localhost:9000"}):
+            args = _make_args(mcp_server="skills", json=True)
+            ctx = _make_ctx(
+                args=args,
+                parsed=SimpleNamespace(warning_records=[], warnings=[]),
+            )
+            rc = _handle_mcp_restart_dispatch(ctx)
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["server"] == "skills"
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._run_async_safely")
+    def test_offline_server_returns_one(self, mock_async, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_restart_dispatch
+
+        mock_async.return_value = {"status": "offline", "error": "connection refused"}
+
+        with patch("core.mcp_registry.get_registered_service", return_value={"url": "http://localhost:9001"}):
+            args = _make_args(mcp_server="skills", json=False)
+            ctx = _make_ctx(args=args)
+            rc = _handle_mcp_restart_dispatch(ctx)
+
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# _handle_beads_schemas_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestBeadsSchemasDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_json_mode_returns_payload(self, _compat, capsys, tmp_path):
+        from aura_cli.dispatch import _handle_beads_schemas_dispatch
+
+        args = _make_args(json=True)
+        ctx = _make_ctx(
+            args=args,
+            project_root=tmp_path,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+        rc = _handle_beads_schemas_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert "schemas" in out
+        assert "schema_version" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_plain_mode_no_rich(self, _compat, capsys, tmp_path):
+        from aura_cli.dispatch import _handle_beads_schemas_dispatch
+
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, project_root=tmp_path)
+
+        with patch.dict("sys.modules", {"rich": None, "rich.console": None, "rich.table": None, "rich.box": None}):
+            rc = _handle_beads_schemas_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "BEADS" in out or "Schema" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_with_config_file(self, _compat, capsys, tmp_path):
+        from aura_cli.dispatch import _handle_beads_schemas_dispatch
+
+        beads_dir = tmp_path / ".beads"
+        beads_dir.mkdir()
+        (beads_dir / "config.yaml").write_text("enabled: true\n")
+        (beads_dir / "interactions.jsonl").write_text('{"id":1}\n{"id":2}\n')
+
+        args = _make_args(json=True)
+        ctx = _make_ctx(
+            args=args,
+            project_root=tmp_path,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+        rc = _handle_beads_schemas_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["interaction_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _handle_agent_list_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestAgentListDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_plain_mode_no_rich(self, _log, _compat, capsys):
+        from aura_cli.dispatch import _handle_agent_list_dispatch
+
+        with patch.dict("sys.modules", {"rich": None, "rich.table": None, "rich.console": None}):
+            ctx = _make_ctx()
+            rc = _handle_agent_list_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Agent" in out or "Total" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_with_rich_calls_log(self, _log, _compat):
+        from aura_cli.dispatch import _handle_agent_list_dispatch
+
+        ctx = _make_ctx()
+        rc = _handle_agent_list_dispatch(ctx)
+        assert rc == 0
+        _log.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_cancel_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCancelDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_run_id_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_cancel_dispatch
+
+        args = _make_args(run_id=None)
+        ctx = _make_ctx(args=args)
+        rc = _handle_cancel_dispatch(ctx)
+        assert rc == 1
+        assert "required" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_unknown_run_id_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_cancel_dispatch
+
+        with (
+            patch("core.running_runs.list_runs", return_value=[]),
+            patch("core.running_runs.cancel_run"),
+        ):
+            args = _make_args(run_id="no-such-run")
+            ctx = _make_ctx(args=args)
+            rc = _handle_cancel_dispatch(ctx)
+
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_successful_cancel_returns_zero(self, _log, _compat, capsys):
+        from aura_cli.dispatch import _handle_cancel_dispatch
+
+        with (
+            patch("core.running_runs.list_runs", return_value=[{"run_id": "run-abc"}]),
+            patch("core.running_runs.cancel_run", return_value=True),
+        ):
+            args = _make_args(run_id="run-abc")
+            ctx = _make_ctx(args=args)
+            rc = _handle_cancel_dispatch(ctx)
+
+        assert rc == 0
+        _log.assert_called()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.log_json")
+    def test_cancel_already_completed_returns_one(self, _log, _compat, capsys):
+        from aura_cli.dispatch import _handle_cancel_dispatch
+
+        with (
+            patch("core.running_runs.list_runs", return_value=[{"run_id": "run-xyz"}]),
+            patch("core.running_runs.cancel_run", return_value=False),
+        ):
+            args = _make_args(run_id="run-xyz")
+            ctx = _make_ctx(args=args)
+            rc = _handle_cancel_dispatch(ctx)
+
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# _handle_sadd_run_dispatch — validation error path
+# ---------------------------------------------------------------------------
+
+
+class TestSaddRunDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_validation_errors_returns_one(self, _compat, capsys, tmp_path):
+        from aura_cli.dispatch import _handle_sadd_run_dispatch
+
+        spec_file = tmp_path / "spec.yaml"
+        spec_file.write_text("title: test\nworkstreams: []\n")
+
+        args = _make_args(spec=str(spec_file), dry_run=True, json=False)
+        rt = _fake_runtime()
+        ctx = _make_ctx(args=args, runtime=rt)
+
+        mock_spec = MagicMock()
+        mock_spec.workstreams = []
+        mock_spec.title = "test"
+        mock_spec.parse_confidence = 1.0
+
+        with (
+            patch("core.sadd.design_spec_parser.DesignSpecParser") as mock_parser_cls,
+            patch("core.sadd.types.validate_spec", return_value=["error1"]),
+        ):
+            mock_parser = MagicMock()
+            mock_parser.parse_file.return_value = mock_spec
+            mock_parser_cls.return_value = mock_parser
+            rc = _handle_sadd_run_dispatch(ctx)
+
+        assert rc == 1
+        assert "Validation" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_missing_spec_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_sadd_run_dispatch
+
+        args = _make_args(spec="/nonexistent/path.yaml", dry_run=True, json=False)
+        ctx = _make_ctx(args=args, runtime=_fake_runtime())
+        rc = _handle_sadd_run_dispatch(ctx)
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# _handle_sadd_status_dispatch — session_id present
+# ---------------------------------------------------------------------------
+
+
+class TestSaddStatusDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_with_session_id_json_mode(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_sadd_status_dispatch
+
+        mock_session = {"id": "sess-1", "title": "Test Session", "status": "completed", "created_at": 1000000.0, "report_json": None}
+
+        with patch("core.sadd.session_store.SessionStore") as mock_store_cls:
+            mock_store = MagicMock()
+            mock_store.get_session.return_value = mock_session
+            mock_store.get_events.return_value = []
+            mock_store.list_checkpoints.return_value = []
+            mock_store_cls.return_value = mock_store
+
+            args = _make_args(json=True, session_id="sess-1")
+            ctx = _make_ctx(
+                args=args,
+                parsed=SimpleNamespace(warning_records=[], warnings=[]),
+            )
+            rc = _handle_sadd_status_dispatch(ctx)
+
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert "session" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_with_session_id_plain_mode(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_sadd_status_dispatch
+
+        mock_session = {"id": "sess-2", "title": "My Session", "status": "running", "created_at": 1000000.0, "report_json": None}
+
+        with patch("core.sadd.session_store.SessionStore") as mock_store_cls:
+            mock_store = MagicMock()
+            mock_store.get_session.return_value = mock_session
+            mock_store.get_events.return_value = []
+            mock_store.list_checkpoints.return_value = []
+            mock_store_cls.return_value = mock_store
+
+            args = _make_args(json=False, session_id="sess-2")
+            ctx = _make_ctx(args=args)
+            rc = _handle_sadd_status_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "My Session" in out or "sess-2" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_sadd_resume_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSaddResumeDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_session_id_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_sadd_resume_dispatch
+
+        args = _make_args(session_id=None)
+        ctx = _make_ctx(args=args)
+        rc = _handle_sadd_resume_dispatch(ctx)
+        assert rc == 1
+        assert "required" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_not_found_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_sadd_resume_dispatch
+
+        with patch("core.sadd.session_store.SessionStore") as mock_store_cls:
+            mock_store = MagicMock()
+            mock_store.load_session_for_resume.return_value = None
+            mock_store_cls.return_value = mock_store
+
+            args = _make_args(session_id="bad-sess")
+            ctx = _make_ctx(args=args)
+            rc = _handle_sadd_resume_dispatch(ctx)
+
+        assert rc == 1
+        assert "not found" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_dry_run_shows_remaining(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_sadd_resume_dispatch
+
+        mock_spec = MagicMock()
+        mock_spec.title = "My SADD"
+        mock_spec.workstreams = [MagicMock(), MagicMock()]
+
+        mock_config_data = MagicMock()
+        mock_graph_state = None
+        raw_results = {}
+
+        with patch("core.sadd.session_store.SessionStore") as mock_store_cls:
+            mock_store = MagicMock()
+            mock_store.load_session_for_resume.return_value = (mock_spec, mock_config_data, mock_graph_state, raw_results)
+            mock_store_cls.return_value = mock_store
+
+            with patch("core.sadd.workstream_graph.WorkstreamGraph") as mock_graph_cls:
+                mock_graph = MagicMock()
+                mock_graph._nodes = {}
+                mock_graph_cls.return_value = mock_graph
+
+                args = _make_args(session_id="good-sess", run=False)
+                rt = _fake_runtime()
+                ctx = _make_ctx(args=args, runtime=rt)
+                rc = _handle_sadd_resume_dispatch(ctx)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "My SADD" in out or "good-sess" in out
+
+
+# ---------------------------------------------------------------------------
+# _handle_innovate_*_dispatch — delegation tests
+# ---------------------------------------------------------------------------
+
+
+class TestInnovateDispatches:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_start(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_start_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_start") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_start_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_list(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_list_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_list") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_list_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_show(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_show_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_show") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_show_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_resume(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_resume_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_resume") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_resume_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_export(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_export_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_export") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_export_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_techniques(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_techniques_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_techniques") as mock_fn:
+            ctx = _make_ctx()
+            rc = _handle_innovate_techniques_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_to_goals(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_to_goals_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_to_goals") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_to_goals_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_innovate_insights(self, _compat):
+        from aura_cli.dispatch import _handle_innovate_insights_dispatch
+
+        with patch("aura_cli.commands._handle_innovate_insights") as mock_fn:
+            rt = _fake_runtime()
+            ctx = _make_ctx(runtime=rt)
+            rc = _handle_innovate_insights_dispatch(ctx)
+            assert rc == 0
+            mock_fn.assert_called_once_with(ctx.args, ctx.runtime)
+
+
+# ---------------------------------------------------------------------------
+# _handle_watch_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestWatchDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_calls_studio_run(self, _compat):
+        from aura_cli.dispatch import _handle_watch_dispatch
+
+        rt = _fake_runtime()
+        rt["orchestrator"].attach_ui_callback = MagicMock()
+
+        with patch("aura_cli.tui.app.AuraStudio") as mock_studio_cls:
+            mock_studio = MagicMock()
+            mock_studio_cls.return_value = mock_studio
+            args = _make_args(autonomous=True)
+            ctx = _make_ctx(args=args, runtime=rt)
+            rc = _handle_watch_dispatch(ctx)
+
+        assert rc == 0
+        mock_studio.run.assert_called_once_with(autonomous=True)
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_no_orchestrator_skips_attach(self, _compat):
+        from aura_cli.dispatch import _handle_watch_dispatch
+
+        rt = _fake_runtime()
+        rt["orchestrator"] = None
+
+        with patch("aura_cli.tui.app.AuraStudio") as mock_studio_cls:
+            mock_studio = MagicMock()
+            mock_studio_cls.return_value = mock_studio
+            args = _make_args(autonomous=False)
+            ctx = _make_ctx(args=args, runtime=rt)
+            rc = _handle_watch_dispatch(ctx)
+
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# _handle_queue_list_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestQueueListDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_empty_queue_message(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_queue_list_dispatch
+
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = []
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_queue_list_dispatch(ctx)
+        assert rc == 0
+        assert "empty" in capsys.readouterr().out.lower()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_non_empty_queue_lists(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_queue_list_dispatch
+
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = ["goal1", "goal2"]
+        args = _make_args(json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+        rc = _handle_queue_list_dispatch(ctx)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "goal1" in out
+        assert "goal2" in out
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_json_mode(self, _compat, capsys):
+        from aura_cli.dispatch import _handle_queue_list_dispatch
+
+        rt = _fake_runtime()
+        rt["goal_queue"].queue = ["g1"]
+        args = _make_args(json=True)
+        ctx = _make_ctx(
+            args=args,
+            runtime=rt,
+            parsed=SimpleNamespace(warning_records=[], warnings=[]),
+        )
+        rc = _handle_queue_list_dispatch(ctx)
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# _handle_history_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_calls_handle_history(self, _compat):
+        from aura_cli.dispatch import _handle_history_dispatch
+
+        rt = _fake_runtime()
+        args = _make_args(limit=5, json=False)
+        ctx = _make_ctx(args=args, runtime=rt)
+
+        with patch("aura_cli.commands._handle_history") as mock_hist:
+            rc = _handle_history_dispatch(ctx)
+
+        assert rc == 0
+        mock_hist.assert_called_once_with(rt["goal_archive"], limit=5, as_json=False)
+
+
+# ---------------------------------------------------------------------------
+# dispatch_command — main routing function
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchCommand:
+    def _make_parsed(self, action, **ns_kwargs):
+        ns = _make_args(action=action, **ns_kwargs)
+        return SimpleNamespace(
+            action=action,
+            namespace=ns,
+            warning_records=[],
+            warnings=[],
+        )
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_unknown_action_returns_one(self, _compat, capsys):
+        from aura_cli.dispatch import dispatch_command
+
+        parsed = self._make_parsed("totally_unknown_action")
+        rc = dispatch_command(parsed, project_root=Path("/proj"))
+        assert rc == 1
+        assert "No dispatch rule" in capsys.readouterr().err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_warning_records_printed_to_stderr(self, _compat, capsys):
+        from aura_cli.dispatch import dispatch_command
+
+        warning = MagicMock()
+        warning.message = "deprecated flag"
+        parsed = SimpleNamespace(
+            action="help",
+            namespace=_make_args(action="help"),
+            warning_records=[warning],
+            warnings=[],
+        )
+
+        with patch("aura_cli.dispatch.render_help", return_value="help text"):
+            rc = dispatch_command(parsed, project_root=Path("/proj"))
+
+        err = capsys.readouterr().err
+        assert "deprecated flag" in err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_plain_warnings_printed_to_stderr(self, _compat, capsys):
+        from aura_cli.dispatch import dispatch_command
+
+        parsed = SimpleNamespace(
+            action="help",
+            namespace=_make_args(action="help"),
+            warning_records=[],
+            warnings=["plain warning msg"],
+        )
+
+        with patch("aura_cli.dispatch.render_help", return_value="help"):
+            rc = dispatch_command(parsed, project_root=Path("/proj"))
+
+        err = capsys.readouterr().err
+        assert "plain warning msg" in err
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._handle_doctor")
+    def test_doctor_action_dispatches(self, mock_doctor, _compat):
+        from aura_cli.dispatch import dispatch_command
+
+        parsed = self._make_parsed("doctor")
+        rc = dispatch_command(parsed, project_root=Path("/proj"))
+        assert rc == 0
+        mock_doctor.assert_called_once()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.render_help", return_value="help output")
+    def test_help_action_dispatches(self, mock_render, _compat, capsys):
+        from aura_cli.dispatch import dispatch_command
+
+        parsed = self._make_parsed("help")
+        rc = dispatch_command(parsed, project_root=Path("/proj"))
+        assert rc == 0
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch._prepare_runtime_context", return_value=1)
+    def test_runtime_required_prep_failure_returns_prep_code(self, mock_prep, _compat):
+        from aura_cli.dispatch import dispatch_command, COMMAND_DISPATCH_REGISTRY
+
+        # Use a runtime-required action
+        action = next(
+            a for a, rule in COMMAND_DISPATCH_REGISTRY.items() if rule.requires_runtime
+        )
+        parsed = self._make_parsed(action)
+        rc = dispatch_command(parsed, project_root=Path("/proj"))
+        assert rc == 1
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.render_help", return_value="json help")
+    def test_json_help_action_dispatches(self, mock_render, _compat, capsys):
+        from aura_cli.dispatch import dispatch_command
+
+        parsed = self._make_parsed("json_help")
+        rc = dispatch_command(parsed, project_root=Path("/proj"))
+        assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# COMMAND_DISPATCH_REGISTRY — structure checks
+# ---------------------------------------------------------------------------
+
+
+class TestCommandDispatchRegistry:
+    def test_registry_is_dict(self):
+        from aura_cli.dispatch import COMMAND_DISPATCH_REGISTRY, DispatchRule
+
+        assert isinstance(COMMAND_DISPATCH_REGISTRY, dict)
+        for action, rule in COMMAND_DISPATCH_REGISTRY.items():
+            assert isinstance(rule, DispatchRule)
+            assert rule.action == action
+            assert callable(rule.handler)
+
+    def test_required_actions_present(self):
+        from aura_cli.dispatch import COMMAND_DISPATCH_REGISTRY
+
+        required = [
+            "help",
+            "doctor",
+            "goal_once",
+            "goal_run",
+            "goal_status",
+            "goal_add",
+            "evolve",
+            "scaffold",
+            "interactive",
+            "cancel",
+        ]
+        for action in required:
+            assert action in COMMAND_DISPATCH_REGISTRY, f"Missing: {action}"
+
+    def test_all_rules_have_handlers(self):
+        from aura_cli.dispatch import COMMAND_DISPATCH_REGISTRY
+
+        for action, rule in COMMAND_DISPATCH_REGISTRY.items():
+            assert rule.handler is not None, f"No handler for {action}"
+
+    def test_studio_is_alias_for_watch(self):
+        from aura_cli.dispatch import COMMAND_DISPATCH_REGISTRY
+
+        assert COMMAND_DISPATCH_REGISTRY["studio"].handler is COMMAND_DISPATCH_REGISTRY["watch"].handler
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_rule helper
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchRule:
+    def test_creates_dispatch_rule(self):
+        from aura_cli.dispatch import _dispatch_rule, DispatchRule
+
+        handler = MagicMock()
+        with patch("aura_cli.dispatch.action_runtime_required", return_value=True):
+            rule = _dispatch_rule("myaction", handler)
+
+        assert isinstance(rule, DispatchRule)
+        assert rule.action == "myaction"
+        assert rule.handler is handler
+        assert rule.requires_runtime is True
+
+    def test_frozen_rule_cannot_be_mutated(self):
+        from aura_cli.dispatch import DispatchRule
+
+        rule = DispatchRule(action="x", requires_runtime=False, handler=lambda: None)
+        with pytest.raises((AttributeError, TypeError)):
+            rule.action = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# RuntimeContext & DispatchContext dataclass tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataclassesExtra:
+    def test_runtime_context_extra_field(self):
+        from aura_cli.dispatch import RuntimeContext
+
+        rc = RuntimeContext(agent="planner", model="gpt-4", verbose=True, dry_run=True, non_interactive=True, timeout=30)
+        assert rc.agent == "planner"
+        assert rc.model == "gpt-4"
+        assert rc.verbose is True
+        assert rc.timeout == 30
+
+    def test_runtime_context_extra_dict(self):
+        from aura_cli.dispatch import RuntimeContext
+
+        rc = RuntimeContext(extra={"foo": "bar"})
+        assert rc.extra["foo"] == "bar"
+
+    def test_dispatch_context_has_runtime_none_by_default(self):
+        from aura_cli.dispatch import DispatchContext
+
+        ctx = DispatchContext(
+            parsed=SimpleNamespace(),
+            project_root=Path("/p"),
+            runtime_factory=MagicMock(),
+            args=SimpleNamespace(),
+        )
+        assert ctx.runtime is None
+
+
+# ---------------------------------------------------------------------------
+# _handle_interactive_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestInteractiveDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_calls_cli_loop(self, _compat):
+        from aura_cli.dispatch import _handle_interactive_dispatch
+
+        rt = _fake_runtime()
+        ctx = _make_ctx(runtime=rt)
+
+        with patch("aura_cli.cli_main.cli_interaction_loop") as mock_loop:
+            rc = _handle_interactive_dispatch(ctx)
+
+        assert rc == 0
+        mock_loop.assert_called_once_with(ctx.args, rt)
+
+
+# ---------------------------------------------------------------------------
+# _handle_mcp_tools_dispatch & _handle_mcp_call_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMcpToolsCallDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.cmd_mcp_tools")
+    def test_mcp_tools_dispatch(self, mock_cmd, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_tools_dispatch
+
+        mock_cmd.return_value = 0
+        ctx = _make_ctx(parsed=SimpleNamespace(warning_records=[], warnings=[]))
+        rc = _handle_mcp_tools_dispatch(ctx)
+        assert rc == 0
+        mock_cmd.assert_called_once()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.cmd_mcp_call")
+    def test_mcp_call_dispatch_passes_args(self, mock_cmd, _compat, capsys):
+        from aura_cli.dispatch import _handle_mcp_call_dispatch
+
+        mock_cmd.return_value = 0
+        args = _make_args(mcp_call="tool_name", mcp_args={"x": 1})
+        ctx = _make_ctx(args=args, parsed=SimpleNamespace(warning_records=[], warnings=[]))
+        rc = _handle_mcp_call_dispatch(ctx)
+        assert rc == 0
+        mock_cmd.assert_called_once_with("tool_name", {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# _handle_diag_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDiagDispatch:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    @patch("aura_cli.dispatch.cmd_diag")
+    def test_diag_dispatch(self, mock_cmd, _compat, capsys):
+        from aura_cli.dispatch import _handle_diag_dispatch
+
+        mock_cmd.return_value = 0
+        ctx = _make_ctx(parsed=SimpleNamespace(warning_records=[], warnings=[]))
+        rc = _handle_diag_dispatch(ctx)
+        assert rc == 0
+        mock_cmd.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_logs_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestLogsDispatchExtra:
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_stream_file(self, _compat):
+        from aura_cli.dispatch import _handle_logs_dispatch
+
+        with patch("aura_cli.tui.log_streamer.LogStreamer") as mock_cls:
+            mock_streamer = MagicMock()
+            mock_cls.return_value = mock_streamer
+            args = _make_args(level="debug", file="/var/log/aura.log", tail=100, follow=False)
+            ctx = _make_ctx(args=args)
+            rc = _handle_logs_dispatch(ctx)
+
+        assert rc == 0
+        mock_streamer.stream_file.assert_called_once()
+
+    @patch("aura_cli.dispatch._sync_cli_compat")
+    def test_stream_stdin(self, _compat):
+        from aura_cli.dispatch import _handle_logs_dispatch
+
+        with patch("aura_cli.tui.log_streamer.LogStreamer") as mock_cls:
+            mock_streamer = MagicMock()
+            mock_cls.return_value = mock_streamer
+            args = _make_args(level="info", file=None, tail=None, follow=False)
+            ctx = _make_ctx(args=args)
+            rc = _handle_logs_dispatch(ctx)
+
+        assert rc == 0
+        mock_streamer.stream_stdin.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_json_printing_callable_with_warnings — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRunJsonPrintingCallableWithWarnings:
+    def test_non_json_output_passes_through(self, capsys):
+        from aura_cli.dispatch import _run_json_printing_callable_with_warnings
+
+        warning = MagicMock()
+        warning.message = "w1"
+        parsed = SimpleNamespace(warning_records=[warning], warnings=[])
+        ctx = _make_ctx(parsed=parsed)
+
+        def func():
+            print("plain text output")
+            return 0
+
+        result = _run_json_printing_callable_with_warnings(ctx, func)
+        out = capsys.readouterr().out
+        assert "plain text output" in out
+        assert result == 0
+
+    def test_empty_output_returns_result(self, capsys):
+        from aura_cli.dispatch import _run_json_printing_callable_with_warnings
+
+        warning = MagicMock()
+        warning.message = "w1"
+        parsed = SimpleNamespace(warning_records=[warning], warnings=[])
+        ctx = _make_ctx(parsed=parsed)
+
+        def func():
+            return 42
+
+        result = _run_json_printing_callable_with_warnings(ctx, func)
+        assert result == 42
+
+    def test_no_warnings_calls_directly(self, capsys):
+        from aura_cli.dispatch import _run_json_printing_callable_with_warnings
+
+        ctx = _make_ctx(parsed=SimpleNamespace(warning_records=[], warnings=[]))
+
+        called_with = []
+
+        def func(a, b):
+            called_with.append((a, b))
+            return 0
+
+        _run_json_printing_callable_with_warnings(ctx, func, "x", "y")
+        assert called_with == [("x", "y")]
+
+
+# ---------------------------------------------------------------------------
+# _print_json_payload
+# ---------------------------------------------------------------------------
+
+
+class TestPrintJsonPayloadExtra:
+    def test_prints_valid_json(self, capsys):
+        from aura_cli.dispatch import _print_json_payload
+
+        _print_json_payload({"a": 1, "b": [1, 2]})
+        out = json.loads(capsys.readouterr().out)
+        assert out["a"] == 1
+
+    def test_with_parsed_object(self, capsys):
+        from aura_cli.dispatch import _print_json_payload
+
+        with patch("aura_cli.dispatch.attach_cli_warnings", return_value={"result": "ok", "_warnings": []}):
+            _print_json_payload({"result": "ok"}, parsed=SimpleNamespace())
+        out = json.loads(capsys.readouterr().out)
+        assert "result" in out
+
+
+# ---------------------------------------------------------------------------
+# _resolve_beads_runtime_override — additional combinations
+# ---------------------------------------------------------------------------
+
+
+class TestBeadsOverrideExtra:
+    def test_multiple_flags_last_one_wins(self):
+        from aura_cli.dispatch import _resolve_beads_runtime_override
+
+        # both beads and no_beads — beads is iterated first, then no_beads overrides
+        args = _make_args(beads=True, no_beads=True)
+        with patch("aura_cli.dispatch.config") as mock_cfg, patch("aura_cli.dispatch.DEFAULT_CONFIG", {"beads": {}}):
+            mock_cfg.get.return_value = {}
+            beads_config, beads_cli = _resolve_beads_runtime_override(args)
+
+        # Result should show the flag combination was processed
+        assert beads_cli is not None
+        assert beads_config is not None
+
+    def test_beads_required_sets_both_enabled_and_required(self):
+        from aura_cli.dispatch import _resolve_beads_runtime_override
+
+        args = _make_args(beads_required=True)
+        with patch("aura_cli.dispatch.config") as mock_cfg, patch("aura_cli.dispatch.DEFAULT_CONFIG", {"beads": {}}):
+            mock_cfg.get.return_value = {}
+            beads_config, beads_cli = _resolve_beads_runtime_override(args)
+
+        assert beads_cli["enabled"] is True
+        assert beads_cli["required"] is True
+
+
+# ---------------------------------------------------------------------------
+# _handle_contract_report_dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestContractReportDispatchExtra:
+    def test_check_mode_failure(self, capsys):
+        from aura_cli.dispatch import _handle_contract_report_dispatch
+
+        args = _make_args(no_dispatch=False, compact=False, check=True)
+        ctx = _make_ctx(args=args)
+
+        with patch("aura_cli.contract_report.build_cli_contract_report") as mock_build, \
+             patch("aura_cli.contract_report.render_cli_contract_report", return_value="report\n"), \
+             patch("aura_cli.contract_report.cli_contract_report_exit_code", return_value=1), \
+             patch("aura_cli.contract_report.cli_contract_report_failure_message", return_value="FAILED"):
+            mock_report = MagicMock()
+            mock_build.return_value = mock_report
+            rc = _handle_contract_report_dispatch(ctx)
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "FAILED" in err
+
+    def test_success_returns_zero(self, capsys):
+        from aura_cli.dispatch import _handle_contract_report_dispatch
+
+        args = _make_args(no_dispatch=True, compact=True, check=False)
+        ctx = _make_ctx(args=args)
+
+        with patch("aura_cli.contract_report.build_cli_contract_report") as mock_build, \
+             patch("aura_cli.contract_report.render_cli_contract_report", return_value="ok\n"), \
+             patch("aura_cli.contract_report.cli_contract_report_exit_code", return_value=0), \
+             patch("aura_cli.contract_report.cli_contract_report_failure_message", return_value=""):
+            mock_report = MagicMock()
+            mock_build.return_value = mock_report
+            rc = _handle_contract_report_dispatch(ctx)
+
+        assert rc == 0

--- a/tests/test_orchestrator_extended.py
+++ b/tests/test_orchestrator_extended.py
@@ -1,0 +1,792 @@
+"""Extended unit tests for core/orchestrator.py — LoopOrchestrator.
+
+Covers advanced features, edge cases, and integration points not in main test file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call, AsyncMock
+import pytest
+import tempfile
+
+from core.orchestrator import LoopOrchestrator, BeadsSyncLoop
+from core.policy import Policy
+from core.file_tools import MismatchOverwriteBlockedError, OldCodeNotFoundError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agents(**overrides):
+    """Return a minimal agents dict with MagicMock instances."""
+    phase_names = ["ingest", "plan", "critique", "synthesize", "act", "verify", "reflect"]
+    agents = {}
+    for name in phase_names:
+        mock = MagicMock(name=name)
+        mock.name = name
+        mock.run.return_value = {"status": "success", "agent_name": name}
+        agents[name] = mock
+    agents.update(overrides)
+    return agents
+
+
+def _make_orchestrator(agents=None, policy=None, project_root=None, **kwargs):
+    """Build a LoopOrchestrator with heavy side-effects patched."""
+    agents = agents or _make_agents()
+    with (
+        patch("core.orchestrator.HookEngine"),
+        patch("core.orchestrator.PhaseDispatcher"),
+        patch("core.orchestrator.memory_controller"),
+        patch("core.orchestrator.log_json"),
+        patch("agents.skills.registry.all_skills", return_value={}, create=True),
+    ):
+        orch = LoopOrchestrator(
+            agents=agents,
+            policy=policy or Policy.from_config({}),
+            project_root=project_root or Path("."),
+            **kwargs,
+        )
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# BeadsSyncLoop Tests
+# ---------------------------------------------------------------------------
+
+
+class TestBeadsSyncLoop:
+    """Test BeadsSyncLoop synchronization trigger."""
+
+    def test_on_cycle_complete_skips_dry_run(self):
+        """Verify dry_run entries don't trigger beads sync."""
+        skill = MagicMock()
+        loop = BeadsSyncLoop(skill)
+        
+        entry = {"dry_run": True}
+        loop.on_cycle_complete(entry)
+        
+        skill.run.assert_not_called()
+
+    def test_on_cycle_complete_syncs_every_n_cycles(self):
+        """Verify beads sync happens every N cycles."""
+        skill = MagicMock()
+        loop = BeadsSyncLoop(skill)
+        
+        # Call 5 times (EVERY_N = 5)
+        for i in range(5):
+            loop.on_cycle_complete({"dry_run": False})
+        
+        # Should trigger on 5th call
+        assert skill.run.call_count == 2  # pull + push
+        
+        # Verify pull and push calls
+        calls = skill.run.call_args_list
+        assert calls[0][0][0] == {"cmd": "dolt", "args": ["pull"]}
+        assert calls[1][0][0] == {"cmd": "dolt", "args": ["push"]}
+
+    def test_on_cycle_complete_handles_non_dict_entry(self):
+        """Verify handling of non-dict entry."""
+        skill = MagicMock()
+        loop = BeadsSyncLoop(skill)
+        
+        # Should not crash on non-dict
+        loop.on_cycle_complete("invalid")
+        skill.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Attachment Methods
+# ---------------------------------------------------------------------------
+
+
+class TestAttachUiCallback:
+    """Test UI callback registration and invocation."""
+
+    def test_attach_ui_callback_appends(self):
+        orch = _make_orchestrator()
+        callback1 = MagicMock()
+        callback2 = MagicMock()
+        
+        orch.attach_ui_callback(callback1)
+        orch.attach_ui_callback(callback2)
+        
+        assert len(orch._ui_callbacks) == 2
+        assert callback1 in orch._ui_callbacks
+        assert callback2 in orch._ui_callbacks
+
+    def test_notify_ui_calls_method_on_all_callbacks(self):
+        orch = _make_orchestrator()
+        callback1 = MagicMock()
+        callback2 = MagicMock()
+        
+        orch.attach_ui_callback(callback1)
+        orch.attach_ui_callback(callback2)
+        
+        orch._notify_ui("on_phase_complete", "plan", {"status": "ok"})
+        
+        callback1.on_phase_complete.assert_called_once_with("plan", {"status": "ok"})
+        callback2.on_phase_complete.assert_called_once_with("plan", {"status": "ok"})
+
+    def test_notify_ui_ignores_missing_method(self):
+        """Verify UI callback doesn't crash if method is missing."""
+        orch = _make_orchestrator()
+        callback = MagicMock(spec=[])  # Empty spec = no methods
+        
+        orch.attach_ui_callback(callback)
+        
+        # Should not raise
+        orch._notify_ui("on_nonexistent_method")
+
+    def test_notify_ui_ignores_callback_exceptions(self):
+        """Verify exceptions in callbacks don't break the orchestrator.
+        
+        Note: _notify_ui only catches TypeError and AttributeError, not general exceptions.
+        """
+        orch = _make_orchestrator()
+        callback = MagicMock()
+        callback.on_event.side_effect = TypeError("Wrong args")
+        
+        orch.attach_ui_callback(callback)
+        
+        # Should not raise (TypeError is caught)
+        orch._notify_ui("on_event", "arg")
+
+
+# ---------------------------------------------------------------------------
+# Improvement Loops
+# ---------------------------------------------------------------------------
+
+
+class TestAttachImprovementLoops:
+    """Test improvement loop registration."""
+
+    def test_attach_improvement_loops_extends_list(self):
+        orch = _make_orchestrator()
+        loop1 = MagicMock()
+        loop2 = MagicMock()
+        
+        orch.attach_improvement_loops(loop1, loop2)
+        
+        assert len(orch._improvement_loops) == 2
+        assert loop1 in orch._improvement_loops
+        assert loop2 in orch._improvement_loops
+
+    def test_attach_improvement_loops_multiple_calls_additive(self):
+        """Verify multiple calls extend the list without deduplication."""
+        orch = _make_orchestrator()
+        loop1 = MagicMock()
+        
+        orch.attach_improvement_loops(loop1)
+        orch.attach_improvement_loops(loop1)
+        
+        assert len(orch._improvement_loops) == 2
+
+
+# ---------------------------------------------------------------------------
+# CASPA Attachment
+# ---------------------------------------------------------------------------
+
+
+class TestAttachCaspa:
+    """Test CASPA-W component attachment."""
+
+    def test_attach_caspa_stores_all_components(self):
+        orch = _make_orchestrator()
+        adaptive = MagicMock()
+        propagation = MagicMock()
+        context_graph = MagicMock()
+        
+        orch.attach_caspa(
+            adaptive_pipeline=adaptive,
+            propagation_engine=propagation,
+            context_graph=context_graph,
+        )
+        
+        assert orch.adaptive_pipeline is adaptive
+        assert orch.propagation_engine is propagation
+        assert orch.context_graph is context_graph
+
+    def test_attach_caspa_allows_none_components(self):
+        """Verify None values are accepted for optional components."""
+        orch = _make_orchestrator()
+        orch.attach_caspa(
+            adaptive_pipeline=None,
+            propagation_engine=None,
+            context_graph=None,
+        )
+        
+        assert orch.adaptive_pipeline is None
+        assert orch.propagation_engine is None
+        assert orch.context_graph is None
+
+    def test_attach_caspa_partial_attachment(self):
+        """Verify that attach_caspa always sets all three attributes.
+        
+        Note: attach_caspa sets all three components, overwriting None values.
+        """
+        orch = _make_orchestrator()
+        initial_graph = MagicMock()
+        orch.context_graph = initial_graph
+        
+        new_adaptive = MagicMock()
+        orch.attach_caspa(adaptive_pipeline=new_adaptive)
+        
+        assert orch.adaptive_pipeline is new_adaptive
+        # When attach_caspa is called with context_graph=None (default), it sets it to None
+        assert orch.context_graph is None
+
+
+# ---------------------------------------------------------------------------
+# Private Methods: _retrieve_hints
+# ---------------------------------------------------------------------------
+
+
+class TestRetrieveHints:
+    """Test hint retrieval for relevance-based planning."""
+
+    def test_retrieve_hints_empty_when_no_store(self):
+        orch = _make_orchestrator()
+        orch.memory_controller = None
+        
+        hints = orch._retrieve_hints("some goal")
+        assert hints == []
+
+    def test_retrieve_hints_empty_when_no_persistent_store(self):
+        orch = _make_orchestrator()
+        orch.memory_controller = MagicMock()
+        orch.memory_controller.persistent_store = None
+        
+        hints = orch._retrieve_hints("some goal")
+        assert hints == []
+
+    def test_retrieve_hints_returns_limit(self):
+        orch = _make_orchestrator()
+        orch.memory_controller = MagicMock()
+        summaries = [{"goal": f"task_{i}"} for i in range(10)]
+        orch.memory_controller.persistent_store.query.return_value = summaries
+        
+        hints = orch._retrieve_hints("task", limit=3)
+        
+        assert len(hints) <= 3
+
+    def test_retrieve_hints_scores_by_keyword_match(self):
+        """Verify keyword relevance scoring."""
+        orch = _make_orchestrator()
+        orch.memory_controller = MagicMock()
+        summaries = [
+            {"status": "success"},  # No keyword match
+            {"status": "success"},  # Has "fix" keyword
+        ]
+        orch.memory_controller.persistent_store.query.return_value = summaries
+        
+        hints = orch._retrieve_hints("fix bug", limit=5)
+        # Should return some hints (order depends on scoring)
+        assert isinstance(hints, list)
+
+    def test_retrieve_hints_handles_query_failure(self):
+        """Verify graceful handling of query errors."""
+        orch = _make_orchestrator()
+        orch.memory_controller = MagicMock()
+        orch.memory_controller.persistent_store.query.side_effect = OSError("DB error")
+        
+        hints = orch._retrieve_hints("goal")
+        assert hints == []
+
+
+# ---------------------------------------------------------------------------
+# File Snapshot and Apply
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotFileState:
+    """Test file state capture before mutation."""
+
+    def test_snapshot_nonexistent_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            orch = _make_orchestrator(project_root=Path(td))
+            
+            snapshot = orch._snapshot_file_state("new_file.py")
+            
+            assert snapshot["file"] == "new_file.py"
+            assert snapshot["existed"] is False
+            assert snapshot["content"] is None
+            assert snapshot["mode"] is None
+
+    def test_snapshot_existing_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            test_file = root / "test.py"
+            test_file.write_text("hello world")
+            
+            orch = _make_orchestrator(project_root=root)
+            snapshot = orch._snapshot_file_state("test.py")
+            
+            assert snapshot["existed"] is True
+            assert snapshot["content"] == "hello world"
+            assert snapshot["mode"] is not None
+
+
+class TestApplyChangeSet:
+    """Test change set application to filesystem."""
+
+    def test_apply_change_set_single_change(self):
+        """Verify single change application."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            test_file = root / "test.py"
+            test_file.write_text("old code")
+            
+            orch = _make_orchestrator(project_root=root)
+            
+            change_set = {
+                "file_path": "test.py",
+                "old_code": "old code",
+                "new_code": "new code",
+            }
+            
+            result = orch._apply_change_set(change_set, dry_run=False)
+            
+            assert "test.py" in result["applied"]
+            assert test_file.read_text() == "new code"
+
+    def test_apply_change_set_dry_run(self):
+        """Verify dry_run doesn't modify files."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            test_file = root / "test.py"
+            test_file.write_text("original")
+            
+            orch = _make_orchestrator(project_root=root)
+            
+            change_set = {
+                "file_path": "test.py",
+                "old_code": "original",
+                "new_code": "modified",
+            }
+            
+            result = orch._apply_change_set(change_set, dry_run=True)
+            
+            assert "test.py" in result["applied"]
+            assert test_file.read_text() == "original"
+
+    def test_apply_change_set_batch(self):
+        """Verify batch changes application."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "a.py").write_text("a_old")
+            (root / "b.py").write_text("b_old")
+            
+            orch = _make_orchestrator(project_root=root)
+            
+            change_set = {
+                "changes": [
+                    {"file_path": "a.py", "old_code": "a_old", "new_code": "a_new"},
+                    {"file_path": "b.py", "old_code": "b_old", "new_code": "b_new"},
+                ]
+            }
+            
+            result = orch._apply_change_set(change_set, dry_run=False)
+            
+            assert "a.py" in result["applied"]
+            assert "b.py" in result["applied"]
+            assert (root / "a.py").read_text() == "a_new"
+            assert (root / "b.py").read_text() == "b_new"
+
+    def test_apply_change_set_continues_on_failure(self):
+        """Verify that one failure doesn't block other changes."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "a.py").write_text("a_old")
+            (root / "b.py").write_text("b_old")
+            
+            orch = _make_orchestrator(project_root=root)
+            
+            change_set = {
+                "changes": [
+                    {"file_path": "a.py", "old_code": "NONEXISTENT", "new_code": "a_new"},
+                    {"file_path": "b.py", "old_code": "b_old", "new_code": "b_new"},
+                ]
+            }
+            
+            result = orch._apply_change_set(change_set, dry_run=False)
+            
+            # b.py should succeed even though a.py failed
+            assert "b.py" in result["applied"]
+            assert len(result["failed"]) == 1
+            assert result["failed"][0]["file"] == "a.py"
+
+    def test_apply_change_set_missing_file_path(self):
+        """Verify handling of missing file_path."""
+        orch = _make_orchestrator()
+        
+        change_set = {"old_code": "x", "new_code": "y"}
+        result = orch._apply_change_set(change_set, dry_run=False)
+        
+        assert result["applied"] == []
+
+    def test_apply_change_set_creates_snapshots(self):
+        """Verify snapshots are captured for all changed files."""
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "test.py").write_text("original")
+            
+            orch = _make_orchestrator(project_root=root)
+            
+            change_set = {
+                "file_path": "test.py",
+                "old_code": "original",
+                "new_code": "modified",
+            }
+            
+            result = orch._apply_change_set(change_set, dry_run=False)
+            
+            assert len(result["snapshots"]) == 1
+            assert result["snapshots"][0]["file"] == "test.py"
+            assert result["snapshots"][0]["content"] == "original"
+
+
+# ---------------------------------------------------------------------------
+# Config Loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadConfigFile:
+    """Test configuration file loading."""
+
+    def test_load_config_file_returns_dict(self):
+        orch = _make_orchestrator()
+        config = orch._load_config_file()
+        
+        assert isinstance(config, dict)
+
+    def test_load_config_file_handles_missing_file(self):
+        """Verify graceful handling of missing config."""
+        orch = _make_orchestrator()
+        # Config path likely doesn't exist in test, should still return dict
+        config = orch._load_config_file()
+        
+        assert isinstance(config, dict)
+
+
+# ---------------------------------------------------------------------------
+# External Goals
+# ---------------------------------------------------------------------------
+
+
+class TestPollExternalGoals:
+    """Test polling for external goal additions."""
+
+    def test_poll_external_goals_handles_none_beads_skill(self):
+        orch = _make_orchestrator()
+        orch._get_beads_skill = MagicMock(return_value=None)
+        
+        result = orch.poll_external_goals()
+        
+        assert result == []
+
+    def test_poll_external_goals_retrieves_from_beads_list(self):
+        """Verify goals are retrieved from BEADS list result."""
+        orch = _make_orchestrator()
+        beads_skill = MagicMock()
+        beads_skill.run.return_value = [
+            {"id": "b1", "title": "task 1"},
+            {"id": "b2", "title": "task 2"},
+        ]
+        orch._get_beads_skill = MagicMock(return_value=beads_skill)
+        
+        result = orch.poll_external_goals()
+        
+        assert len(result) == 2
+        assert "b1" in result[0]
+        assert "task 1" in result[0]
+
+    def test_poll_external_goals_retrieves_from_beads_dict(self):
+        """Verify goals are retrieved from BEADS dict result."""
+        orch = _make_orchestrator()
+        beads_skill = MagicMock()
+        beads_skill.run.return_value = {
+            "beads": [
+                {"id": "b1", "title": "task 1"},
+            ]
+        }
+        orch._get_beads_skill = MagicMock(return_value=beads_skill)
+        
+        result = orch.poll_external_goals()
+        
+        assert len(result) >= 1
+
+    def test_poll_external_goals_handles_beads_error(self):
+        """Verify graceful handling of BEADS errors."""
+        orch = _make_orchestrator()
+        beads_skill = MagicMock()
+        beads_skill.run.side_effect = Exception("BEADS error")
+        orch._get_beads_skill = MagicMock(return_value=beads_skill)
+        
+        result = orch.poll_external_goals()
+        
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+
+class TestShutdown:
+    """Test orchestrator shutdown."""
+
+    def test_shutdown_is_async(self):
+        """Verify shutdown is an async method."""
+        import inspect
+        
+        orch = _make_orchestrator()
+        assert inspect.iscoroutinefunction(orch.shutdown)
+
+
+# ---------------------------------------------------------------------------
+# Async Dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchTask:
+    """Test async task dispatch."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_task_unknown_agent(self):
+        """Verify handling of unknown agent."""
+        from core.types import TaskRequest
+        
+        orch = _make_orchestrator()
+        orch.agents = {}
+        
+        request = TaskRequest(
+            task_id="t1",
+            agent_name="unknown",
+            input_data={}
+        )
+        
+        result = await orch._dispatch_task(request)
+        
+        assert result.status == "error"
+        assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_task_legacy_agent(self):
+        """Verify legacy agent execution."""
+        from core.types import TaskRequest
+        
+        agents = _make_agents()
+        agents["test_agent"] = MagicMock()
+        agents["test_agent"].run.return_value = {"result": "ok"}
+        
+        orch = _make_orchestrator(agents=agents)
+        
+        request = TaskRequest(
+            task_id="t1",
+            agent_name="test_agent",
+            input_data={"data": "test"}
+        )
+        
+        result = await orch._dispatch_task(request)
+        
+        assert result.status == "success"
+        assert result.output == {"result": "ok"}
+
+    @pytest.mark.asyncio
+    async def test_dispatch_task_legacy_agent_error(self):
+        """Verify error handling in legacy agent execution."""
+        from core.types import TaskRequest
+        
+        agents = _make_agents()
+        agents["test_agent"] = MagicMock()
+        agents["test_agent"].run.side_effect = ValueError("Agent error")
+        
+        orch = _make_orchestrator(agents=agents)
+        
+        request = TaskRequest(
+            task_id="t1",
+            agent_name="test_agent",
+            input_data={}
+        )
+        
+        result = await orch._dispatch_task(request)
+        
+        assert result.status == "error"
+        assert "Agent error" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_orchestrator_with_agents(self):
+        """Verify orchestrator handles non-empty agent dict."""
+        agents = _make_agents()
+        orch = _make_orchestrator(agents=agents)
+        assert len(orch.agents) > 0
+
+    def test_orchestrator_with_custom_project_root(self):
+        """Verify custom project root is stored correctly."""
+        custom_root = Path("/custom/root")
+        orch = _make_orchestrator(project_root=custom_root)
+        
+        assert orch.project_root == custom_root
+
+    def test_orchestrator_strict_schema_mode(self):
+        """Verify strict schema flag is stored."""
+        orch = _make_orchestrator(strict_schema=True)
+        assert orch.strict_schema is True
+
+    def test_consecutive_fails_counter_initialized(self):
+        """Verify consecutive failures counter starts at zero."""
+        orch = _make_orchestrator()
+        assert orch._consecutive_fails == 0
+
+    def test_current_goal_none_initially(self):
+        """Verify current goal is None on initialization."""
+        orch = _make_orchestrator()
+        assert orch.current_goal is None
+
+    def test_active_cycle_summary_none_initially(self):
+        """Verify active cycle summary is None on initialization."""
+        orch = _make_orchestrator()
+        assert orch.active_cycle_summary is None
+
+
+# ---------------------------------------------------------------------------
+# Human Gate
+# ---------------------------------------------------------------------------
+
+
+class TestHumanGate:
+    """Test human gating mechanism."""
+
+    def test_human_gate_initialized(self):
+        """Verify human gate is initialized."""
+        orch = _make_orchestrator()
+        assert orch.human_gate is not None
+
+    def test_human_gate_is_object(self):
+        """Verify human gate is an instance of HumanGate."""
+        from core.human_gate import HumanGate
+        
+        orch = _make_orchestrator()
+        assert isinstance(orch.human_gate, HumanGate)
+
+
+# ---------------------------------------------------------------------------
+# Runtime Modes
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeMode:
+    """Test runtime mode configuration."""
+
+    def test_runtime_mode_stored(self):
+        """Verify runtime mode is stored."""
+        orch = _make_orchestrator(runtime_mode="sandbox")
+        assert orch.runtime_mode == "sandbox"
+
+    def test_runtime_mode_defaults_to_full(self):
+        """Verify default runtime mode is 'full'."""
+        orch = _make_orchestrator()
+        assert orch.runtime_mode == "full"
+
+
+# ---------------------------------------------------------------------------
+# Beads Configuration
+# ---------------------------------------------------------------------------
+
+
+class TestBeadsConfiguration:
+    """Test Beads synchronization configuration."""
+
+    def test_beads_disabled_by_default(self):
+        """Verify Beads is disabled by default."""
+        orch = _make_orchestrator()
+        assert orch.beads_enabled is False
+
+    def test_beads_enabled_configuration(self):
+        """Verify Beads can be enabled."""
+        orch = _make_orchestrator(beads_enabled=True)
+        assert orch.beads_enabled is True
+
+    def test_beads_required_configuration(self):
+        """Verify Beads required flag."""
+        orch = _make_orchestrator(beads_required=True)
+        assert orch.beads_required is True
+
+    def test_beads_scope_configuration(self):
+        """Verify Beads scope configuration."""
+        orch = _make_orchestrator(beads_scope="cycle")
+        assert orch.beads_scope == "cycle"
+
+
+# ---------------------------------------------------------------------------
+# Capability Management
+# ---------------------------------------------------------------------------
+
+
+class TestCapabilityConfiguration:
+    """Test capability management configuration."""
+
+    def test_auto_add_capabilities_enabled_by_default(self):
+        """Verify auto capability addition is enabled by default."""
+        orch = _make_orchestrator()
+        assert orch.auto_add_capabilities is True
+
+    def test_auto_add_capabilities_can_be_disabled(self):
+        """Verify auto capability addition can be disabled."""
+        orch = _make_orchestrator(auto_add_capabilities=False)
+        assert orch.auto_add_capabilities is False
+
+    def test_auto_queue_missing_capabilities_enabled_by_default(self):
+        """Verify auto queuing of missing capabilities is enabled by default."""
+        orch = _make_orchestrator()
+        assert orch.auto_queue_missing_capabilities is True
+
+    def test_auto_provision_mcp_disabled_by_default(self):
+        """Verify auto MCP provisioning is disabled by default."""
+        orch = _make_orchestrator()
+        assert orch.auto_provision_mcp is False
+
+    def test_auto_start_mcp_servers_disabled_by_default(self):
+        """Verify auto MCP server start is disabled by default."""
+        orch = _make_orchestrator()
+        assert orch.auto_start_mcp_servers is False
+
+
+# ---------------------------------------------------------------------------
+# Optional Agents
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalAgents:
+    """Test optional specialized agents."""
+
+    def test_self_correction_agent_optional(self):
+        """Verify self correction agent is optional."""
+        orch = _make_orchestrator()
+        assert orch.self_correction_agent is None
+
+    def test_investigation_agent_optional(self):
+        """Verify investigation agent is optional."""
+        orch = _make_orchestrator()
+        assert orch.investigation_agent is None
+
+    def test_root_cause_analysis_agent_optional(self):
+        """Verify root cause analysis agent is optional."""
+        orch = _make_orchestrator()
+        assert orch.root_cause_analysis_agent is None
+
+    def test_debugger_agent_optional(self):
+        """Verify debugger agent is optional."""
+        orch = _make_orchestrator()
+        assert orch.debugger is None

--- a/tests/test_workflow_engine_extended.py
+++ b/tests/test_workflow_engine_extended.py
@@ -89,6 +89,7 @@ class TestRunStepCallableWithTimeout:
         def slow():
             time.sleep(10)
             return {}
+
         with pytest.raises(TimeoutError):
             _run_step_callable_with_timeout(slow, 0.05)
 
@@ -103,6 +104,7 @@ class TestExecuteStepEdgeCases:
     def test_fn_raises_returns_failed(self):
         def boom(inputs):
             raise ValueError("exploded")
+
         step = WorkflowStep(name="boom", fn=boom, retry=RetryPolicy(max_attempts=1), timeout_s=5.0)
         result = _execute_step(step, {}, {})
         assert result.status == "failed"
@@ -110,44 +112,56 @@ class TestExecuteStepEdgeCases:
 
     def test_skip_if_false_single_part_truthy(self):
         step = WorkflowStep(
-            name="conditional", fn=lambda i: {"ran": True},
-            skip_if_false="prev_step", retry=RetryPolicy(max_attempts=1),
+            name="conditional",
+            fn=lambda i: {"ran": True},
+            skip_if_false="prev_step",
+            retry=RetryPolicy(max_attempts=1),
         )
         result = _execute_step(step, {"prev_step": {"some_key": True}}, {})
         assert result.status == "ok"
 
     def test_skip_if_false_single_part_falsy_empty_dict(self):
         step = WorkflowStep(
-            name="conditional", fn=lambda i: {"ran": True},
-            skip_if_false="prev_step", retry=RetryPolicy(max_attempts=1),
+            name="conditional",
+            fn=lambda i: {"ran": True},
+            skip_if_false="prev_step",
+            retry=RetryPolicy(max_attempts=1),
         )
         result = _execute_step(step, {"prev_step": {}}, {})
         assert result.status == "skipped"
 
     def test_skip_if_false_dotted_falsy_key(self):
         step = WorkflowStep(
-            name="conditioned", fn=lambda i: {"done": True},
-            skip_if_false="checker.passed", retry=RetryPolicy(max_attempts=1),
+            name="conditioned",
+            fn=lambda i: {"done": True},
+            skip_if_false="checker.passed",
+            retry=RetryPolicy(max_attempts=1),
         )
         result = _execute_step(step, {"checker": {"passed": False}}, {})
         assert result.status == "skipped"
 
     def test_skip_if_false_missing_source_step(self):
         step = WorkflowStep(
-            name="conditioned", fn=lambda i: {"done": True},
-            skip_if_false="missing_step.key", retry=RetryPolicy(max_attempts=1),
+            name="conditioned",
+            fn=lambda i: {"done": True},
+            skip_if_false="missing_step.key",
+            retry=RetryPolicy(max_attempts=1),
         )
         result = _execute_step(step, {}, {})
         assert result.status == "skipped"
 
     def test_retry_on_error_output(self):
         call_count = {"n": 0}
+
         def error_fn(inputs):
             call_count["n"] += 1
             return {"error": "transient"}
+
         step = WorkflowStep(
-            name="retry_step", fn=error_fn,
-            retry=RetryPolicy(max_attempts=3, backoff_base=0.0), timeout_s=0,
+            name="retry_step",
+            fn=error_fn,
+            retry=RetryPolicy(max_attempts=3, backoff_base=0.0),
+            timeout_s=0,
         )
         result = _execute_step(step, {}, {})
         assert result.status == "failed"
@@ -156,14 +170,18 @@ class TestExecuteStepEdgeCases:
 
     def test_retry_succeeds_on_second_attempt(self):
         attempts = {"n": 0}
+
         def flaky(inputs):
             attempts["n"] += 1
             if attempts["n"] == 1:
                 return {"error": "first attempt"}
             return {"value": "success"}
+
         step = WorkflowStep(
-            name="flaky", fn=flaky,
-            retry=RetryPolicy(max_attempts=3, backoff_base=0.0), timeout_s=0,
+            name="flaky",
+            fn=flaky,
+            retry=RetryPolicy(max_attempts=3, backoff_base=0.0),
+            timeout_s=0,
         )
         result = _execute_step(step, {}, {})
         assert result.status == "ok"
@@ -173,8 +191,12 @@ class TestExecuteStepEdgeCases:
         def slow(inputs):
             time.sleep(10)
             return {"done": True}
+
         step = WorkflowStep(
-            name="slow_step", fn=slow, retry=RetryPolicy(max_attempts=1), timeout_s=0.05,
+            name="slow_step",
+            fn=slow,
+            retry=RetryPolicy(max_attempts=1),
+            timeout_s=0.05,
         )
         result = _execute_step(step, {}, {})
         assert result.status == "timeout"
@@ -184,8 +206,10 @@ class TestExecuteStepEdgeCases:
         mock_skill.run.return_value = {"skill_output": 1}
         with patch("agents.skills.registry.all_skills", return_value={"my_sk": mock_skill}):
             step = WorkflowStep(
-                name="skill_step", skill_name="my_sk",
-                retry=RetryPolicy(max_attempts=1), timeout_s=0,
+                name="skill_step",
+                skill_name="my_sk",
+                retry=RetryPolicy(max_attempts=1),
+                timeout_s=0,
             )
             result = _execute_step(step, {}, {"project_root": "."})
         assert result.status == "ok"
@@ -193,8 +217,10 @@ class TestExecuteStepEdgeCases:
 
     def test_execute_step_elapsed_ms_positive(self):
         step = WorkflowStep(
-            name="timed", fn=lambda i: {"x": 1},
-            retry=RetryPolicy(max_attempts=1), timeout_s=0,
+            name="timed",
+            fn=lambda i: {"x": 1},
+            retry=RetryPolicy(max_attempts=1),
+            timeout_s=0,
         )
         result = _execute_step(step, {}, {})
         assert result.elapsed_ms >= 0.0
@@ -203,7 +229,8 @@ class TestExecuteStepEdgeCases:
 class TestWireInputsExtended:
     def test_wildcard_merges_entire_output(self):
         step = WorkflowStep(
-            name="s", fn=lambda i: i,
+            name="s",
+            fn=lambda i: i,
             inputs_from={"_unused": "prev.*"},
         )
         result = _wire_inputs(step, {"prev": {"a": 1, "b": 2}}, {})
@@ -212,7 +239,8 @@ class TestWireInputsExtended:
 
     def test_inputs_from_missing_key_gives_none(self):
         step = WorkflowStep(
-            name="s", fn=lambda i: i,
+            name="s",
+            fn=lambda i: i,
             inputs_from={"x": "prev_step.no_such_key"},
         )
         result = _wire_inputs(step, {"prev_step": {"other": 99}}, {})
@@ -220,7 +248,8 @@ class TestWireInputsExtended:
 
     def test_static_inputs_override_initial(self):
         step = WorkflowStep(
-            name="s", fn=lambda i: i,
+            name="s",
+            fn=lambda i: i,
             static_inputs={"key": "static_val"},
         )
         result = _wire_inputs(step, {}, {"key": "initial_val"})
@@ -309,39 +338,56 @@ class TestWorkflowEngineStateMachineExtended:
 class TestWorkflowEngineFailurePaths:
     def test_step_failure_sets_execution_failed(self):
         engine = WorkflowEngine()
-        engine.define(WorkflowDefinition(
-            name="fail_wf",
-            steps=[WorkflowStep(
-                name="bad", fn=lambda i: {"error": "always fails"},
-                retry=RetryPolicy(max_attempts=1),
-            )],
-        ))
+        engine.define(
+            WorkflowDefinition(
+                name="fail_wf",
+                steps=[
+                    WorkflowStep(
+                        name="bad",
+                        fn=lambda i: {"error": "always fails"},
+                        retry=RetryPolicy(max_attempts=1),
+                    )
+                ],
+            )
+        )
         exec_id = engine.run_workflow("fail_wf", {})
         status = engine.execution_status(exec_id)
         assert status["status"] == "failed"
 
     def test_total_retry_budget_exhausted(self):
         engine = WorkflowEngine()
-        engine.define(WorkflowDefinition(
-            name="budget_wf", max_retries_total=1,
-            steps=[WorkflowStep(
-                name="fail1", fn=lambda i: {"error": "boom"},
-                retry=RetryPolicy(max_attempts=2, backoff_base=0.0),
-            )],
-        ))
+        engine.define(
+            WorkflowDefinition(
+                name="budget_wf",
+                max_retries_total=1,
+                steps=[
+                    WorkflowStep(
+                        name="fail1",
+                        fn=lambda i: {"error": "boom"},
+                        retry=RetryPolicy(max_attempts=2, backoff_base=0.0),
+                    )
+                ],
+            )
+        )
         exec_id = engine.run_workflow("budget_wf", {})
         status = engine.execution_status(exec_id)
         assert status["status"] == "failed"
 
     def test_step_timeout_marks_execution_failed(self):
         engine = WorkflowEngine()
-        engine.define(WorkflowDefinition(
-            name="timeout_wf",
-            steps=[WorkflowStep(
-                name="slow", fn=lambda i: time.sleep(10) or {},
-                retry=RetryPolicy(max_attempts=1), timeout_s=0.05,
-            )],
-        ))
+        engine.define(
+            WorkflowDefinition(
+                name="timeout_wf",
+                steps=[
+                    WorkflowStep(
+                        name="slow",
+                        fn=lambda i: time.sleep(10) or {},
+                        retry=RetryPolicy(max_attempts=1),
+                        timeout_s=0.05,
+                    )
+                ],
+            )
+        )
         exec_id = engine.run_workflow("timeout_wf", {})
         status = engine.execution_status(exec_id)
         assert status["status"] == "failed"
@@ -349,13 +395,15 @@ class TestWorkflowEngineFailurePaths:
 
     def test_second_step_failure_stops_workflow(self):
         engine = WorkflowEngine()
-        engine.define(WorkflowDefinition(
-            name="two_step",
-            steps=[
-                WorkflowStep("ok_step", fn=lambda i: {"x": 1}, retry=RetryPolicy(max_attempts=1)),
-                WorkflowStep("bad_step", fn=lambda i: {"error": "boom"}, retry=RetryPolicy(max_attempts=1)),
-            ],
-        ))
+        engine.define(
+            WorkflowDefinition(
+                name="two_step",
+                steps=[
+                    WorkflowStep("ok_step", fn=lambda i: {"x": 1}, retry=RetryPolicy(max_attempts=1)),
+                    WorkflowStep("bad_step", fn=lambda i: {"error": "boom"}, retry=RetryPolicy(max_attempts=1)),
+                ],
+            )
+        )
         exec_id = engine.run_workflow("two_step", {})
         status = engine.execution_status(exec_id)
         assert status["status"] == "failed"
@@ -365,16 +413,20 @@ class TestWorkflowEngineFailurePaths:
 class TestWorkflowEngineMultiStep:
     def test_multi_step_workflow_all_ok(self):
         engine = WorkflowEngine()
-        engine.define(WorkflowDefinition(
-            name="multi",
-            steps=[
-                WorkflowStep("step_a", fn=lambda i: {"val": 10}, retry=RetryPolicy(max_attempts=1)),
-                WorkflowStep(
-                    "step_b", fn=lambda i: {"doubled": i.get("val", 0) * 2},
-                    inputs_from={"val": "step_a.val"}, retry=RetryPolicy(max_attempts=1),
-                ),
-            ],
-        ))
+        engine.define(
+            WorkflowDefinition(
+                name="multi",
+                steps=[
+                    WorkflowStep("step_a", fn=lambda i: {"val": 10}, retry=RetryPolicy(max_attempts=1)),
+                    WorkflowStep(
+                        "step_b",
+                        fn=lambda i: {"doubled": i.get("val", 0) * 2},
+                        inputs_from={"val": "step_a.val"},
+                        retry=RetryPolicy(max_attempts=1),
+                    ),
+                ],
+            )
+        )
         exec_id = engine.run_workflow("multi", {})
         status = engine.execution_status(exec_id)
         assert status["status"] == "completed"
@@ -383,16 +435,20 @@ class TestWorkflowEngineMultiStep:
 
     def test_skip_step_propagates(self):
         engine = WorkflowEngine()
-        engine.define(WorkflowDefinition(
-            name="skip_wf",
-            steps=[
-                WorkflowStep("check", fn=lambda i: {"ok": False}, retry=RetryPolicy(max_attempts=1)),
-                WorkflowStep(
-                    "guarded", fn=lambda i: {"ran": True},
-                    skip_if_false="check.ok", retry=RetryPolicy(max_attempts=1),
-                ),
-            ],
-        ))
+        engine.define(
+            WorkflowDefinition(
+                name="skip_wf",
+                steps=[
+                    WorkflowStep("check", fn=lambda i: {"ok": False}, retry=RetryPolicy(max_attempts=1)),
+                    WorkflowStep(
+                        "guarded",
+                        fn=lambda i: {"ran": True},
+                        skip_if_false="check.ok",
+                        retry=RetryPolicy(max_attempts=1),
+                    ),
+                ],
+            )
+        )
         exec_id = engine.run_workflow("skip_wf", {})
         status = engine.execution_status(exec_id)
         assert status["status"] == "completed"
@@ -663,10 +719,13 @@ class TestBuiltinWorkflowDefinitions:
         assert defs["onboarding_analysis"]["step_count"] == 4
 
     def test_define_overwrites_existing(self):
-        self.engine.define(WorkflowDefinition(
-            name="security_audit", description="overwritten",
-            steps=[WorkflowStep("only_step", fn=lambda i: {})],
-        ))
+        self.engine.define(
+            WorkflowDefinition(
+                name="security_audit",
+                description="overwritten",
+                steps=[WorkflowStep("only_step", fn=lambda i: {})],
+            )
+        )
         defs = {d["name"]: d for d in self.engine.list_definitions()}
         assert defs["security_audit"]["step_count"] == 1
 
@@ -695,81 +754,151 @@ class TestGetEngineSingletonExtended:
 class TestIsTerminal:
     def test_execution_is_terminal_completed(self):
         exc = WorkflowExecution(
-            id="x", workflow_name="w", status="completed",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+            id="x",
+            workflow_name="w",
+            status="completed",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert exc.is_terminal() is True
 
     def test_execution_is_terminal_failed(self):
         exc = WorkflowExecution(
-            id="x", workflow_name="w", status="failed",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+            id="x",
+            workflow_name="w",
+            status="failed",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert exc.is_terminal() is True
 
     def test_execution_is_terminal_cancelled(self):
         exc = WorkflowExecution(
-            id="x", workflow_name="w", status="cancelled",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+            id="x",
+            workflow_name="w",
+            status="cancelled",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert exc.is_terminal() is True
 
     def test_execution_not_terminal_running(self):
         exc = WorkflowExecution(
-            id="x", workflow_name="w", status="running",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+            id="x",
+            workflow_name="w",
+            status="running",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert exc.is_terminal() is False
 
     def test_execution_not_terminal_paused(self):
         exc = WorkflowExecution(
-            id="x", workflow_name="w", status="paused",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+            id="x",
+            workflow_name="w",
+            status="paused",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert exc.is_terminal() is False
 
     def test_loop_is_terminal_completed(self):
         loop = AgenticLoop(
-            id="l", goal="g", max_cycles=5, current_cycle=5,
-            status="completed", history=[], stop_reason="done",
-            score=0.0, started_at=0.0, updated_at=0.0,
+            id="l",
+            goal="g",
+            max_cycles=5,
+            current_cycle=5,
+            status="completed",
+            history=[],
+            stop_reason="done",
+            score=0.0,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert loop.is_terminal() is True
 
     def test_loop_is_terminal_failed(self):
         loop = AgenticLoop(
-            id="l", goal="g", max_cycles=5, current_cycle=5,
-            status="failed", history=[], stop_reason="err",
-            score=0.0, started_at=0.0, updated_at=0.0,
+            id="l",
+            goal="g",
+            max_cycles=5,
+            current_cycle=5,
+            status="failed",
+            history=[],
+            stop_reason="err",
+            score=0.0,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert loop.is_terminal() is True
 
     def test_loop_is_terminal_stopped(self):
         loop = AgenticLoop(
-            id="l", goal="g", max_cycles=5, current_cycle=2,
-            status="stopped", history=[], stop_reason="user",
-            score=0.0, started_at=0.0, updated_at=0.0,
+            id="l",
+            goal="g",
+            max_cycles=5,
+            current_cycle=2,
+            status="stopped",
+            history=[],
+            stop_reason="user",
+            score=0.0,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert loop.is_terminal() is True
 
     def test_loop_not_terminal_running(self):
         loop = AgenticLoop(
-            id="l", goal="g", max_cycles=5, current_cycle=1,
-            status="running", history=[], stop_reason=None,
-            score=0.0, started_at=0.0, updated_at=0.0,
+            id="l",
+            goal="g",
+            max_cycles=5,
+            current_cycle=1,
+            status="running",
+            history=[],
+            stop_reason=None,
+            score=0.0,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert loop.is_terminal() is False
 
     def test_loop_not_terminal_paused(self):
         loop = AgenticLoop(
-            id="l", goal="g", max_cycles=5, current_cycle=1,
-            status="paused", history=[], stop_reason=None,
-            score=0.0, started_at=0.0, updated_at=0.0,
+            id="l",
+            goal="g",
+            max_cycles=5,
+            current_cycle=1,
+            status="paused",
+            history=[],
+            stop_reason=None,
+            score=0.0,
+            started_at=0.0,
+            updated_at=0.0,
         )
         assert loop.is_terminal() is False
 
@@ -778,9 +907,16 @@ class TestJournalResilience:
     def test_journal_execution_handles_db_error(self):
         engine = WorkflowEngine()
         exc = WorkflowExecution(
-            id="x", workflow_name="wf", status="running",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+            id="x",
+            workflow_name="wf",
+            status="running",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=0.0,
+            updated_at=0.0,
         )
         with patch("core.workflow_engine._open_db", side_effect=Exception("db down")):
             try:
@@ -791,9 +927,16 @@ class TestJournalResilience:
     def test_journal_loop_handles_db_error(self):
         engine = WorkflowEngine()
         loop = AgenticLoop(
-            id="l", goal="g", max_cycles=3, current_cycle=0,
-            status="running", history=[], stop_reason=None,
-            score=0.0, started_at=0.0, updated_at=0.0,
+            id="l",
+            goal="g",
+            max_cycles=3,
+            current_cycle=0,
+            status="running",
+            history=[],
+            stop_reason=None,
+            score=0.0,
+            started_at=0.0,
+            updated_at=0.0,
         )
         with patch("core.workflow_engine._open_db", side_effect=Exception("db down")):
             try:
@@ -836,9 +979,12 @@ class TestRetryPolicyArithmetic:
 class TestDataclasses:
     def test_step_result_with_error(self):
         sr = StepResult(
-            step_name="s", status="failed",
-            output={"error": "boom"}, attempts=2,
-            elapsed_ms=123.4, error="boom",
+            step_name="s",
+            status="failed",
+            output={"error": "boom"},
+            attempts=2,
+            elapsed_ms=123.4,
+            error="boom",
         )
         assert sr.step_name == "s"
         assert sr.status == "failed"
@@ -846,8 +992,10 @@ class TestDataclasses:
 
     def test_loop_cycle_fields(self):
         lc = LoopCycle(
-            cycle_number=3, status="ok",
-            phase_outputs={"plan": ["step1"]}, elapsed_ms=55.5,
+            cycle_number=3,
+            status="ok",
+            phase_outputs={"plan": ["step1"]},
+            elapsed_ms=55.5,
         )
         assert lc.cycle_number == 3
         assert lc.stop_reason is None
@@ -855,10 +1003,16 @@ class TestDataclasses:
 
     def test_workflow_execution_total_retries_default(self):
         exc = WorkflowExecution(
-            id="e1", workflow_name="wf", status="running",
-            current_step_index=0, step_outputs={}, history=[],
-            initial_inputs={}, error=None,
-            started_at=time.time(), updated_at=time.time(),
+            id="e1",
+            workflow_name="wf",
+            status="running",
+            current_step_index=0,
+            step_outputs={},
+            history=[],
+            initial_inputs={},
+            error=None,
+            started_at=time.time(),
+            updated_at=time.time(),
         )
         assert exc.total_retries_used == 0
 

--- a/tests/test_workflow_engine_extended.py
+++ b/tests/test_workflow_engine_extended.py
@@ -1,0 +1,872 @@
+"""Extended unit tests for core/workflow_engine.py — Sprint 9 coverage."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch, call
+
+import pytest
+
+from core.workflow_engine import (
+    AgenticLoop,
+    LoopCycle,
+    RetryPolicy,
+    StepResult,
+    WorkflowDefinition,
+    WorkflowEngine,
+    WorkflowExecution,
+    WorkflowStep,
+    _execute_step,
+    _run_skill,
+    _run_step_callable_with_timeout,
+    _wire_inputs,
+    get_engine,
+)
+
+
+def _simple_step(name="s1", fn=None) -> WorkflowStep:
+    if fn is None:
+        fn = lambda inputs: {"result": "ok"}
+    return WorkflowStep(name=name, fn=fn, retry=RetryPolicy(max_attempts=1))
+
+
+def _simple_def(name="wf", step_fn=None) -> WorkflowDefinition:
+    return WorkflowDefinition(name=name, steps=[_simple_step("s1", fn=step_fn)])
+
+
+class TestRunSkill:
+    def test_run_skill_calls_registry(self):
+        mock_skill = MagicMock()
+        mock_skill.run.return_value = {"output": "data"}
+        with patch("agents.skills.registry.all_skills", return_value={"my_skill": mock_skill}):
+            result = _run_skill("my_skill", {"key": "val"})
+        assert result == {"output": "data"}
+        mock_skill.run.assert_called_once_with({"key": "val"})
+
+    def test_run_skill_unknown_returns_error(self):
+        with patch("agents.skills.registry.all_skills", return_value={}):
+            result = _run_skill("nonexistent_skill", {})
+        assert "error" in result
+        assert "Unknown skill" in result["error"]
+
+    def test_run_skill_import_error_returns_error(self):
+        with patch("agents.skills.registry.all_skills", side_effect=ImportError("no module")):
+            result = _run_skill("any_skill", {})
+        assert "error" in result
+
+    def test_run_skill_exception_in_run_returns_error(self):
+        mock_skill = MagicMock()
+        mock_skill.run.side_effect = RuntimeError("skill crashed")
+        with patch("agents.skills.registry.all_skills", return_value={"bad_skill": mock_skill}):
+            result = _run_skill("bad_skill", {})
+        assert "error" in result
+
+
+class TestRunStepCallableWithTimeout:
+    def test_no_timeout_runs_directly(self):
+        fn = lambda: {"answer": 42}
+        ok, result = _run_step_callable_with_timeout(fn, 0)
+        assert ok is True
+        assert result == {"answer": 42}
+
+    def test_negative_timeout_runs_directly(self):
+        fn = lambda: "direct"
+        ok, result = _run_step_callable_with_timeout(fn, -1)
+        assert ok is True
+        assert result == "direct"
+
+    def test_timeout_within_limit_succeeds(self):
+        fn = lambda: {"fast": True}
+        ok, result = _run_step_callable_with_timeout(fn, 5.0)
+        assert ok is True
+        assert result == {"fast": True}
+
+    def test_timeout_exceeded_raises(self):
+        def slow():
+            time.sleep(10)
+            return {}
+        with pytest.raises(TimeoutError):
+            _run_step_callable_with_timeout(slow, 0.05)
+
+
+class TestExecuteStepEdgeCases:
+    def test_step_with_no_skill_and_no_fn_returns_error(self):
+        step = WorkflowStep(name="empty", retry=RetryPolicy(max_attempts=1))
+        result = _execute_step(step, {}, {})
+        assert result.status == "failed"
+        assert "no skill_name or fn" in result.error
+
+    def test_fn_raises_returns_failed(self):
+        def boom(inputs):
+            raise ValueError("exploded")
+        step = WorkflowStep(name="boom", fn=boom, retry=RetryPolicy(max_attempts=1), timeout_s=5.0)
+        result = _execute_step(step, {}, {})
+        assert result.status == "failed"
+        assert "ValueError" in result.error
+
+    def test_skip_if_false_single_part_truthy(self):
+        step = WorkflowStep(
+            name="conditional", fn=lambda i: {"ran": True},
+            skip_if_false="prev_step", retry=RetryPolicy(max_attempts=1),
+        )
+        result = _execute_step(step, {"prev_step": {"some_key": True}}, {})
+        assert result.status == "ok"
+
+    def test_skip_if_false_single_part_falsy_empty_dict(self):
+        step = WorkflowStep(
+            name="conditional", fn=lambda i: {"ran": True},
+            skip_if_false="prev_step", retry=RetryPolicy(max_attempts=1),
+        )
+        result = _execute_step(step, {"prev_step": {}}, {})
+        assert result.status == "skipped"
+
+    def test_skip_if_false_dotted_falsy_key(self):
+        step = WorkflowStep(
+            name="conditioned", fn=lambda i: {"done": True},
+            skip_if_false="checker.passed", retry=RetryPolicy(max_attempts=1),
+        )
+        result = _execute_step(step, {"checker": {"passed": False}}, {})
+        assert result.status == "skipped"
+
+    def test_skip_if_false_missing_source_step(self):
+        step = WorkflowStep(
+            name="conditioned", fn=lambda i: {"done": True},
+            skip_if_false="missing_step.key", retry=RetryPolicy(max_attempts=1),
+        )
+        result = _execute_step(step, {}, {})
+        assert result.status == "skipped"
+
+    def test_retry_on_error_output(self):
+        call_count = {"n": 0}
+        def error_fn(inputs):
+            call_count["n"] += 1
+            return {"error": "transient"}
+        step = WorkflowStep(
+            name="retry_step", fn=error_fn,
+            retry=RetryPolicy(max_attempts=3, backoff_base=0.0), timeout_s=0,
+        )
+        result = _execute_step(step, {}, {})
+        assert result.status == "failed"
+        assert call_count["n"] == 3
+        assert result.attempts == 3
+
+    def test_retry_succeeds_on_second_attempt(self):
+        attempts = {"n": 0}
+        def flaky(inputs):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                return {"error": "first attempt"}
+            return {"value": "success"}
+        step = WorkflowStep(
+            name="flaky", fn=flaky,
+            retry=RetryPolicy(max_attempts=3, backoff_base=0.0), timeout_s=0,
+        )
+        result = _execute_step(step, {}, {})
+        assert result.status == "ok"
+        assert result.attempts == 2
+
+    def test_timeout_step_returns_timeout_status(self):
+        def slow(inputs):
+            time.sleep(10)
+            return {"done": True}
+        step = WorkflowStep(
+            name="slow_step", fn=slow, retry=RetryPolicy(max_attempts=1), timeout_s=0.05,
+        )
+        result = _execute_step(step, {}, {})
+        assert result.status == "timeout"
+
+    def test_step_uses_skill_name(self):
+        mock_skill = MagicMock()
+        mock_skill.run.return_value = {"skill_output": 1}
+        with patch("agents.skills.registry.all_skills", return_value={"my_sk": mock_skill}):
+            step = WorkflowStep(
+                name="skill_step", skill_name="my_sk",
+                retry=RetryPolicy(max_attempts=1), timeout_s=0,
+            )
+            result = _execute_step(step, {}, {"project_root": "."})
+        assert result.status == "ok"
+        assert result.output["skill_output"] == 1
+
+    def test_execute_step_elapsed_ms_positive(self):
+        step = WorkflowStep(
+            name="timed", fn=lambda i: {"x": 1},
+            retry=RetryPolicy(max_attempts=1), timeout_s=0,
+        )
+        result = _execute_step(step, {}, {})
+        assert result.elapsed_ms >= 0.0
+
+
+class TestWireInputsExtended:
+    def test_wildcard_merges_entire_output(self):
+        step = WorkflowStep(
+            name="s", fn=lambda i: i,
+            inputs_from={"_unused": "prev.*"},
+        )
+        result = _wire_inputs(step, {"prev": {"a": 1, "b": 2}}, {})
+        assert result["a"] == 1
+        assert result["b"] == 2
+
+    def test_inputs_from_missing_key_gives_none(self):
+        step = WorkflowStep(
+            name="s", fn=lambda i: i,
+            inputs_from={"x": "prev_step.no_such_key"},
+        )
+        result = _wire_inputs(step, {"prev_step": {"other": 99}}, {})
+        assert result["x"] is None
+
+    def test_static_inputs_override_initial(self):
+        step = WorkflowStep(
+            name="s", fn=lambda i: i,
+            static_inputs={"key": "static_val"},
+        )
+        result = _wire_inputs(step, {}, {"key": "initial_val"})
+        assert result["key"] == "static_val"
+
+    def test_initial_inputs_propagated(self):
+        step = WorkflowStep(name="s", fn=lambda i: i)
+        result = _wire_inputs(step, {}, {"project_root": "/root"})
+        assert result["project_root"] == "/root"
+
+
+class TestWorkflowEngineStateMachineExtended:
+    def setup_method(self):
+        self.engine = WorkflowEngine()
+        self.engine.define(_simple_def("wf"))
+
+    def test_run_workflow_unknown_raises_key_error(self):
+        with pytest.raises(KeyError, match="not defined"):
+            self.engine.run_workflow("no_such_workflow", {})
+
+    def test_pause_terminal_execution_raises_value_error(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        with pytest.raises(ValueError, match="already terminal"):
+            self.engine.pause_execution(exec_id)
+
+    def test_cancel_terminal_execution_raises_value_error(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        with pytest.raises(ValueError, match="already terminal"):
+            self.engine.cancel_execution(exec_id)
+
+    def test_pause_missing_exec_raises_key_error(self):
+        with pytest.raises(KeyError):
+            self.engine.pause_execution("nonexistent-id")
+
+    def test_cancel_missing_exec_raises_key_error(self):
+        with pytest.raises(KeyError):
+            self.engine.cancel_execution("nonexistent-id")
+
+    def test_execution_status_not_found(self):
+        status = self.engine.execution_status("nonexistent")
+        assert status["status"] == "not_found"
+
+    def test_get_step_output_missing_execution_raises(self):
+        with pytest.raises(KeyError):
+            self.engine.get_step_output("bad-id", "step1")
+
+    def test_get_step_output_missing_step_raises(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        with pytest.raises(KeyError):
+            self.engine.get_step_output(exec_id, "no_such_step")
+
+    def test_get_step_output_returns_dict(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        output = self.engine.get_step_output(exec_id, "s1")
+        assert isinstance(output, dict)
+
+    def test_list_executions_no_filter(self):
+        self.engine.run_workflow("wf", {})
+        items = self.engine.list_executions()
+        assert len(items) >= 1
+
+    def test_list_executions_with_status_filter(self):
+        self.engine.run_workflow("wf", {})
+        completed = self.engine.list_executions(status_filter="completed")
+        for item in completed:
+            assert item["status"] == "completed"
+
+    def test_execution_status_has_history(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        status = self.engine.execution_status(exec_id)
+        assert "history" in status
+        assert len(status["history"]) >= 1
+        assert status["history"][0]["step"] == "s1"
+
+    def test_execution_status_has_step_output_keys(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        status = self.engine.execution_status(exec_id)
+        assert "step_output_keys" in status
+
+    def test_resume_non_paused_raises(self):
+        exec_id = self.engine.run_workflow("wf", {})
+        with pytest.raises(ValueError, match="not 'paused'"):
+            self.engine.run_workflow("wf", {}, resume_exec_id=exec_id)
+
+
+class TestWorkflowEngineFailurePaths:
+    def test_step_failure_sets_execution_failed(self):
+        engine = WorkflowEngine()
+        engine.define(WorkflowDefinition(
+            name="fail_wf",
+            steps=[WorkflowStep(
+                name="bad", fn=lambda i: {"error": "always fails"},
+                retry=RetryPolicy(max_attempts=1),
+            )],
+        ))
+        exec_id = engine.run_workflow("fail_wf", {})
+        status = engine.execution_status(exec_id)
+        assert status["status"] == "failed"
+
+    def test_total_retry_budget_exhausted(self):
+        engine = WorkflowEngine()
+        engine.define(WorkflowDefinition(
+            name="budget_wf", max_retries_total=1,
+            steps=[WorkflowStep(
+                name="fail1", fn=lambda i: {"error": "boom"},
+                retry=RetryPolicy(max_attempts=2, backoff_base=0.0),
+            )],
+        ))
+        exec_id = engine.run_workflow("budget_wf", {})
+        status = engine.execution_status(exec_id)
+        assert status["status"] == "failed"
+
+    def test_step_timeout_marks_execution_failed(self):
+        engine = WorkflowEngine()
+        engine.define(WorkflowDefinition(
+            name="timeout_wf",
+            steps=[WorkflowStep(
+                name="slow", fn=lambda i: time.sleep(10) or {},
+                retry=RetryPolicy(max_attempts=1), timeout_s=0.05,
+            )],
+        ))
+        exec_id = engine.run_workflow("timeout_wf", {})
+        status = engine.execution_status(exec_id)
+        assert status["status"] == "failed"
+        assert "timed out" in status["error"]
+
+    def test_second_step_failure_stops_workflow(self):
+        engine = WorkflowEngine()
+        engine.define(WorkflowDefinition(
+            name="two_step",
+            steps=[
+                WorkflowStep("ok_step", fn=lambda i: {"x": 1}, retry=RetryPolicy(max_attempts=1)),
+                WorkflowStep("bad_step", fn=lambda i: {"error": "boom"}, retry=RetryPolicy(max_attempts=1)),
+            ],
+        ))
+        exec_id = engine.run_workflow("two_step", {})
+        status = engine.execution_status(exec_id)
+        assert status["status"] == "failed"
+        assert "bad_step" in status["error"]
+
+
+class TestWorkflowEngineMultiStep:
+    def test_multi_step_workflow_all_ok(self):
+        engine = WorkflowEngine()
+        engine.define(WorkflowDefinition(
+            name="multi",
+            steps=[
+                WorkflowStep("step_a", fn=lambda i: {"val": 10}, retry=RetryPolicy(max_attempts=1)),
+                WorkflowStep(
+                    "step_b", fn=lambda i: {"doubled": i.get("val", 0) * 2},
+                    inputs_from={"val": "step_a.val"}, retry=RetryPolicy(max_attempts=1),
+                ),
+            ],
+        ))
+        exec_id = engine.run_workflow("multi", {})
+        status = engine.execution_status(exec_id)
+        assert status["status"] == "completed"
+        b_out = engine.get_step_output(exec_id, "step_b")
+        assert b_out["doubled"] == 20
+
+    def test_skip_step_propagates(self):
+        engine = WorkflowEngine()
+        engine.define(WorkflowDefinition(
+            name="skip_wf",
+            steps=[
+                WorkflowStep("check", fn=lambda i: {"ok": False}, retry=RetryPolicy(max_attempts=1)),
+                WorkflowStep(
+                    "guarded", fn=lambda i: {"ran": True},
+                    skip_if_false="check.ok", retry=RetryPolicy(max_attempts=1),
+                ),
+            ],
+        ))
+        exec_id = engine.run_workflow("skip_wf", {})
+        status = engine.execution_status(exec_id)
+        assert status["status"] == "completed"
+        assert status["history"][1]["status"] == "skipped"
+
+
+class TestAgenticLoopOperations:
+    def setup_method(self):
+        self.engine = WorkflowEngine()
+
+    def test_create_loop_returns_id(self):
+        loop_id = self.engine.create_loop("test goal", max_cycles=3)
+        assert loop_id
+        status = self.engine.loop_status(loop_id)
+        assert status["status"] == "running"
+
+    def test_loop_status_not_found(self):
+        result = self.engine.loop_status("bad-id")
+        assert result["status"] == "not_found"
+
+    def test_stop_loop_not_found_raises(self):
+        with pytest.raises(KeyError):
+            self.engine.stop_loop("nonexistent")
+
+    def test_stop_loop_terminal_raises(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        loop.status = "completed"
+        with pytest.raises(ValueError, match="already terminal"):
+            self.engine.stop_loop(loop_id)
+
+    def test_stop_loop_succeeds(self):
+        loop_id = self.engine.create_loop("goal")
+        self.engine.stop_loop(loop_id, reason="test_stop")
+        status = self.engine.loop_status(loop_id)
+        assert status["status"] == "stopped"
+        assert status["stop_reason"] == "test_stop"
+
+    def test_pause_loop_not_found_raises(self):
+        with pytest.raises(KeyError):
+            self.engine.pause_loop("nonexistent")
+
+    def test_pause_loop_terminal_raises(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        loop.status = "stopped"
+        with pytest.raises(ValueError, match="already terminal"):
+            self.engine.pause_loop(loop_id)
+
+    def test_pause_loop_succeeds(self):
+        loop_id = self.engine.create_loop("goal")
+        self.engine.pause_loop(loop_id)
+        status = self.engine.loop_status(loop_id)
+        assert status["status"] == "paused"
+
+    def test_resume_loop_not_found_raises(self):
+        with pytest.raises(KeyError):
+            self.engine.resume_loop("nonexistent")
+
+    def test_resume_loop_not_paused_raises(self):
+        loop_id = self.engine.create_loop("goal")
+        with pytest.raises(ValueError, match="not 'paused'"):
+            self.engine.resume_loop(loop_id)
+
+    def test_resume_loop_succeeds(self):
+        loop_id = self.engine.create_loop("goal")
+        self.engine.pause_loop(loop_id)
+        self.engine.resume_loop(loop_id)
+        status = self.engine.loop_status(loop_id)
+        assert status["status"] == "running"
+
+    def test_list_loops_no_filter(self):
+        self.engine.create_loop("goal A")
+        self.engine.create_loop("goal B")
+        items = self.engine.list_loops()
+        assert len(items) >= 2
+
+    def test_list_loops_status_filter(self):
+        loop_id = self.engine.create_loop("filtered goal")
+        self.engine.stop_loop(loop_id)
+        stopped = self.engine.list_loops(status_filter="stopped")
+        assert all(l["status"] == "stopped" for l in stopped)
+
+
+class TestLoopTick:
+    def setup_method(self):
+        self.engine = WorkflowEngine()
+
+    def test_loop_tick_not_found(self):
+        result = self.engine.loop_tick("nonexistent")
+        assert "error" in result
+
+    def test_loop_tick_already_terminal(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        loop.status = "completed"
+        result = self.engine.loop_tick(loop_id)
+        assert "error" in result
+
+    def test_loop_tick_max_cycles_reached_at_zero(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=0)
+        result = self.engine.loop_tick(loop_id)
+        assert result.get("stop_reason") == "max_cycles_reached"
+
+    def test_loop_tick_orchestrator_exception(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=5)
+        mock_orch = MagicMock()
+        mock_orch.run_cycle.side_effect = RuntimeError("orch boom")
+        self.engine._orchestrator = mock_orch
+        result = self.engine.loop_tick(loop_id)
+        assert result["cycle_status"] == "failed"
+        status = self.engine.loop_status(loop_id)
+        assert status["status"] == "failed"
+
+    def test_loop_tick_with_stop_reason(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=5)
+        mock_orch = MagicMock()
+        mock_orch.run_cycle.return_value = {
+            "stop_reason": "goal_achieved",
+            "phase_outputs": {"plan": {"key": "val"}},
+        }
+        self.engine._orchestrator = mock_orch
+        result = self.engine.loop_tick(loop_id)
+        assert result["stop_reason"] == "goal_achieved"
+        assert self.engine.loop_status(loop_id)["status"] == "completed"
+
+    def test_loop_tick_no_stop_reason_increments(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=3)
+        mock_orch = MagicMock()
+        mock_orch.run_cycle.return_value = {"phase_outputs": {}}
+        self.engine._orchestrator = mock_orch
+        result = self.engine.loop_tick(loop_id)
+        assert result["cycle"] == 1
+        assert result["cycle_status"] == "ok"
+
+    def test_loop_tick_last_cycle_completes(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=1)
+        mock_orch = MagicMock()
+        mock_orch.run_cycle.return_value = {"phase_outputs": {}}
+        self.engine._orchestrator = mock_orch
+        result = self.engine.loop_tick(loop_id)
+        assert result["status"] == "completed"
+        assert result["stop_reason"] == "max_cycles_reached"
+
+    def test_loop_tick_history_updated(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=3)
+        mock_orch = MagicMock()
+        mock_orch.run_cycle.return_value = {"phase_outputs": {}}
+        self.engine._orchestrator = mock_orch
+        self.engine.loop_tick(loop_id)
+        status = self.engine.loop_status(loop_id)
+        assert len(status["history"]) == 1
+
+    def test_loop_tick_elapsed_ms_in_result(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=3)
+        mock_orch = MagicMock()
+        mock_orch.run_cycle.return_value = {"phase_outputs": {}}
+        self.engine._orchestrator = mock_orch
+        result = self.engine.loop_tick(loop_id)
+        assert "elapsed_ms" in result
+        assert result["elapsed_ms"] >= 0
+
+
+class TestCheckLoopHealth:
+    def setup_method(self):
+        self.engine = WorkflowEngine()
+
+    def test_loop_not_found(self):
+        result = self.engine.check_loop_health("missing")
+        assert result["healthy"] is False
+        assert "error" in result
+
+    def test_terminal_loop_is_healthy(self):
+        loop_id = self.engine.create_loop("goal")
+        self.engine.stop_loop(loop_id)
+        result = self.engine.check_loop_health(loop_id)
+        assert result["healthy"] is True
+
+    def test_active_recent_loop_is_healthy(self):
+        loop_id = self.engine.create_loop("goal")
+        result = self.engine.check_loop_health(loop_id, stall_threshold_s=9999)
+        assert result["healthy"] is True
+
+    def test_stale_loop_detected(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        loop.updated_at = time.time() - 400
+        result = self.engine.check_loop_health(loop_id, stall_threshold_s=300)
+        assert result["healthy"] is False
+
+    def test_repeated_error_detected(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        err = "same error repeated"
+        loop.history = [
+            LoopCycle(1, "failed", {}, 100, error=err),
+            LoopCycle(2, "failed", {}, 100, error=err),
+            LoopCycle(3, "failed", {}, 100, error=err),
+        ]
+        result = self.engine.check_loop_health(loop_id, stall_threshold_s=9999)
+        assert result["healthy"] is False
+        assert len(result["warnings"]) > 0
+
+    def test_different_errors_no_deadlock(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        loop.history = [
+            LoopCycle(1, "failed", {}, 100, error="err1"),
+            LoopCycle(2, "failed", {}, 100, error="err2"),
+            LoopCycle(3, "failed", {}, 100, error="err3"),
+        ]
+        result = self.engine.check_loop_health(loop_id, stall_threshold_s=9999)
+        assert result["healthy"] is True
+
+    def test_fewer_than_3_cycles_no_repeated_error(self):
+        loop_id = self.engine.create_loop("goal")
+        loop = self.engine._get_loop(loop_id)
+        loop.history = [
+            LoopCycle(1, "failed", {}, 100, error="e"),
+            LoopCycle(2, "failed", {}, 100, error="e"),
+        ]
+        result = self.engine.check_loop_health(loop_id, stall_threshold_s=9999)
+        assert result["healthy"] is True
+
+    def test_cycles_remaining_computed(self):
+        loop_id = self.engine.create_loop("goal", max_cycles=5)
+        loop = self.engine._get_loop(loop_id)
+        loop.current_cycle = 2
+        result = self.engine.check_loop_health(loop_id, stall_threshold_s=9999)
+        assert result["cycles_remaining"] == 3
+
+
+class TestLoopStatusDetail:
+    def test_loop_status_fields(self):
+        engine = WorkflowEngine()
+        loop_id = engine.create_loop("my goal", max_cycles=7)
+        status = engine.loop_status(loop_id)
+        assert status["id"] == loop_id
+        assert status["goal"] == "my goal"
+        assert status["max_cycles"] == 7
+        assert status["current_cycle"] == 0
+        assert "elapsed_s" in status
+        assert isinstance(status["history"], list)
+
+
+class TestBuiltinWorkflowDefinitions:
+    def setup_method(self):
+        self.engine = WorkflowEngine()
+
+    def test_security_audit_registered(self):
+        defs = {d["name"]: d for d in self.engine.list_definitions()}
+        assert "security_audit" in defs
+        assert defs["security_audit"]["step_count"] == 4
+
+    def test_code_quality_registered(self):
+        defs = {d["name"]: d for d in self.engine.list_definitions()}
+        assert "code_quality" in defs
+        assert defs["code_quality"]["step_count"] == 5
+
+    def test_release_prep_registered(self):
+        defs = {d["name"]: d for d in self.engine.list_definitions()}
+        assert "release_prep" in defs
+        assert defs["release_prep"]["step_count"] == 4
+
+    def test_onboarding_analysis_registered(self):
+        defs = {d["name"]: d for d in self.engine.list_definitions()}
+        assert "onboarding_analysis" in defs
+        assert defs["onboarding_analysis"]["step_count"] == 4
+
+    def test_define_overwrites_existing(self):
+        self.engine.define(WorkflowDefinition(
+            name="security_audit", description="overwritten",
+            steps=[WorkflowStep("only_step", fn=lambda i: {})],
+        ))
+        defs = {d["name"]: d for d in self.engine.list_definitions()}
+        assert defs["security_audit"]["step_count"] == 1
+
+    def test_list_definitions_has_steps_key(self):
+        for d in self.engine.list_definitions():
+            assert "steps" in d
+            assert isinstance(d["steps"], list)
+
+
+class TestGetEngineSingletonExtended:
+    def test_get_engine_returns_engine_instance(self):
+        engine = get_engine()
+        assert isinstance(engine, WorkflowEngine)
+
+    def test_get_engine_is_singleton(self):
+        e1 = get_engine()
+        e2 = get_engine()
+        assert e1 is e2
+
+    def test_get_engine_has_definitions(self):
+        engine = get_engine()
+        names = [d["name"] for d in engine.list_definitions()]
+        assert "security_audit" in names
+
+
+class TestIsTerminal:
+    def test_execution_is_terminal_completed(self):
+        exc = WorkflowExecution(
+            id="x", workflow_name="w", status="completed",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+        )
+        assert exc.is_terminal() is True
+
+    def test_execution_is_terminal_failed(self):
+        exc = WorkflowExecution(
+            id="x", workflow_name="w", status="failed",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+        )
+        assert exc.is_terminal() is True
+
+    def test_execution_is_terminal_cancelled(self):
+        exc = WorkflowExecution(
+            id="x", workflow_name="w", status="cancelled",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+        )
+        assert exc.is_terminal() is True
+
+    def test_execution_not_terminal_running(self):
+        exc = WorkflowExecution(
+            id="x", workflow_name="w", status="running",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+        )
+        assert exc.is_terminal() is False
+
+    def test_execution_not_terminal_paused(self):
+        exc = WorkflowExecution(
+            id="x", workflow_name="w", status="paused",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+        )
+        assert exc.is_terminal() is False
+
+    def test_loop_is_terminal_completed(self):
+        loop = AgenticLoop(
+            id="l", goal="g", max_cycles=5, current_cycle=5,
+            status="completed", history=[], stop_reason="done",
+            score=0.0, started_at=0.0, updated_at=0.0,
+        )
+        assert loop.is_terminal() is True
+
+    def test_loop_is_terminal_failed(self):
+        loop = AgenticLoop(
+            id="l", goal="g", max_cycles=5, current_cycle=5,
+            status="failed", history=[], stop_reason="err",
+            score=0.0, started_at=0.0, updated_at=0.0,
+        )
+        assert loop.is_terminal() is True
+
+    def test_loop_is_terminal_stopped(self):
+        loop = AgenticLoop(
+            id="l", goal="g", max_cycles=5, current_cycle=2,
+            status="stopped", history=[], stop_reason="user",
+            score=0.0, started_at=0.0, updated_at=0.0,
+        )
+        assert loop.is_terminal() is True
+
+    def test_loop_not_terminal_running(self):
+        loop = AgenticLoop(
+            id="l", goal="g", max_cycles=5, current_cycle=1,
+            status="running", history=[], stop_reason=None,
+            score=0.0, started_at=0.0, updated_at=0.0,
+        )
+        assert loop.is_terminal() is False
+
+    def test_loop_not_terminal_paused(self):
+        loop = AgenticLoop(
+            id="l", goal="g", max_cycles=5, current_cycle=1,
+            status="paused", history=[], stop_reason=None,
+            score=0.0, started_at=0.0, updated_at=0.0,
+        )
+        assert loop.is_terminal() is False
+
+
+class TestJournalResilience:
+    def test_journal_execution_handles_db_error(self):
+        engine = WorkflowEngine()
+        exc = WorkflowExecution(
+            id="x", workflow_name="wf", status="running",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None, started_at=0.0, updated_at=0.0,
+        )
+        with patch("core.workflow_engine._open_db", side_effect=Exception("db down")):
+            try:
+                engine._journal_execution(exc)
+            except Exception:
+                pytest.fail("_journal_execution should swallow DB errors")
+
+    def test_journal_loop_handles_db_error(self):
+        engine = WorkflowEngine()
+        loop = AgenticLoop(
+            id="l", goal="g", max_cycles=3, current_cycle=0,
+            status="running", history=[], stop_reason=None,
+            score=0.0, started_at=0.0, updated_at=0.0,
+        )
+        with patch("core.workflow_engine._open_db", side_effect=Exception("db down")):
+            try:
+                engine._journal_loop(loop)
+            except Exception:
+                pytest.fail("_journal_loop should swallow DB errors")
+
+
+class TestGetOrchestrator:
+    def test_cached_after_first_call(self):
+        engine = WorkflowEngine()
+        mock_orch = MagicMock()
+        engine._orchestrator = mock_orch
+        assert engine._get_orchestrator() is mock_orch
+        assert engine._get_orchestrator() is mock_orch
+
+
+class TestRetryPolicyArithmetic:
+    def test_sleep_for_capped_at_max_backoff(self):
+        policy = RetryPolicy(backoff_base=1.0, max_backoff=10.0)
+        assert policy.sleep_for(100) == 10.0
+
+    def test_sleep_for_zero_attempt(self):
+        policy = RetryPolicy(backoff_base=2.0)
+        assert policy.sleep_for(0) == 2.0
+
+    def test_sleep_for_first_attempt(self):
+        policy = RetryPolicy(backoff_base=1.0, max_backoff=100.0)
+        assert policy.sleep_for(1) == 2.0
+
+    def test_sleep_for_second_attempt(self):
+        policy = RetryPolicy(backoff_base=0.5, max_backoff=100.0)
+        assert policy.sleep_for(2) == 2.0
+
+    def test_sleep_for_custom_max_backoff(self):
+        policy = RetryPolicy(backoff_base=5.0, max_backoff=8.0)
+        assert policy.sleep_for(3) == 8.0  # 5*8=40 > 8 → capped
+
+
+class TestDataclasses:
+    def test_step_result_with_error(self):
+        sr = StepResult(
+            step_name="s", status="failed",
+            output={"error": "boom"}, attempts=2,
+            elapsed_ms=123.4, error="boom",
+        )
+        assert sr.step_name == "s"
+        assert sr.status == "failed"
+        assert sr.error == "boom"
+
+    def test_loop_cycle_fields(self):
+        lc = LoopCycle(
+            cycle_number=3, status="ok",
+            phase_outputs={"plan": ["step1"]}, elapsed_ms=55.5,
+        )
+        assert lc.cycle_number == 3
+        assert lc.stop_reason is None
+        assert lc.error is None
+
+    def test_workflow_execution_total_retries_default(self):
+        exc = WorkflowExecution(
+            id="e1", workflow_name="wf", status="running",
+            current_step_index=0, step_outputs={}, history=[],
+            initial_inputs={}, error=None,
+            started_at=time.time(), updated_at=time.time(),
+        )
+        assert exc.total_retries_used == 0
+
+    def test_workflow_step_default_retry_policy(self):
+        step = WorkflowStep(name="s")
+        assert step.retry.max_attempts == 3
+        assert step.retry.backoff_base == 0.5
+
+    def test_workflow_definition_default_max_retries(self):
+        wf = WorkflowDefinition(name="w", steps=[])
+        assert wf.max_retries_total == 0


### PR DESCRIPTION
## Sprint 9 Coverage Fleet

### Summary
- **Coverage**: 25% → **28.95%** (+3.95 points)
- **Tests**: 1081 → **1545 passing** (+464), 0 failures

### New test files
| File | Tests | Target |
|------|-------|--------|
| `tests/test_dispatch_extended.py` | 120 | `aura_cli/dispatch.py` |
| `tests/test_orchestrator_extended.py` | 58 | `core/orchestrator.py` |
| `tests/test_context_graph_extended.py` | 59 | `core/context_graph.py` |
| `tests/test_workflow_engine_extended.py` | 106 | `core/workflow_engine.py` |
| `tests/test_config_manager.py` | 121 | `core/config_manager.py` |

### Coverage gate
`fail_under` raised **25 → 28**

### Contamination hygiene
Each agent commit was audited; unauthorized production/docs file deletions were stripped via reset+cherry-pick before push.