### PR TITLE
refactor(mcp): extract runtime bootstrap ownership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,8 @@ python3 scripts/triage_tests.py --timeout 30
 | Command | Purpose |
 |---------|---------|
 | `python3 main.py` | CLI via `aura_cli.cli_main:main()` |
-| `python3 -m aura_cli.server` | Start FastAPI server |
-| `python3 tools/mcp_server.py` | Start main MCP server (port 8001) |
+| `python3 -m aura_cli.server` | Start canonical dev-tools FastAPI server (port 8001) |
+| `python3 tools/mcp_server.py` | Start legacy MCP compatibility server |
 | `python3 tools/sadd_mcp_server.py` | Start SADD MCP server (port 8020) |
 | `python3 tools/observability_mcp.py` | Start Observability MCP (port 8030) |
 | `bash run_aura.sh` | Convenience wrapper for CLI |

--- a/aura_cli/api/runtime_bootstrap.py
+++ b/aura_cli/api/runtime_bootstrap.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+
+@dataclass
+class RuntimeBootstrapState:
+    runtime: dict[str, Any] = field(default_factory=dict)
+    orchestrator: Any = None
+    model_adapter: Any = None
+    memory_store: Any = None
+    runtime_init_error: str | None = None
+
+
+def current_project_root(default_root: Path) -> Path:
+    configured_root = os.getenv("AURA_PROJECT_ROOT")
+    return Path(configured_root).resolve() if configured_root else default_root.resolve()
+
+
+def run_db_migrations(log_json: Callable[..., None]) -> None:
+    """Run auth and brain DB migrations idempotently before accepting requests."""
+    try:
+        from core.db_migrations import migrate_auth_db, migrate_brain_db  # noqa: PLC0415
+    except ImportError:  # pragma: no cover
+        log_json("WARN", "aura_db_migrations_unavailable", details={"reason": "core.db_migrations not importable"})
+        return
+
+    try:
+        from core.auth import _default_auth_db_path  # noqa: PLC0415
+    except ImportError:  # pragma: no cover
+
+        def _default_auth_db_path() -> Path:  # type: ignore[misc]
+            custom = os.environ.get("AURA_AUTH_DB_PATH")
+            if custom:
+                return Path(custom)
+            return Path.home() / ".local" / "share" / "aura" / "auth.db"
+
+    auth_db_path = Path(os.environ["AURA_AUTH_DB_PATH"]) if os.environ.get("AURA_AUTH_DB_PATH") else _default_auth_db_path()
+    brain_db_path = Path(os.environ.get("AURA_BRAIN_DB_PATH", "memory/brain_v2.db"))
+
+    auth_versions = migrate_auth_db(auth_db_path)
+    brain_versions = migrate_brain_db(brain_db_path)
+    log_json(
+        "INFO",
+        "aura_db_migrations_applied",
+        details={"auth_versions": auth_versions, "brain_versions": brain_versions},
+    )
+
+
+def apply_runtime_state(state: RuntimeBootstrapState, runtime_state: dict[str, Any], shared_state_module: Any) -> None:
+    state.runtime = runtime_state
+    state.orchestrator = runtime_state.get("orchestrator")
+    state.model_adapter = runtime_state.get("model_adapter")
+    state.memory_store = runtime_state.get("memory_store")
+
+    shared_state_module.runtime = state.runtime
+    shared_state_module.orchestrator = state.orchestrator
+    shared_state_module.model_adapter = state.model_adapter
+    shared_state_module.memory_store = state.memory_store
+
+
+async def ensure_runtime_initialized(
+    *,
+    state: RuntimeBootstrapState,
+    project_root: Path,
+    create_runtime_func: Callable[..., dict[str, Any]],
+    shared_state_module: Any,
+    log_json: Callable[..., None],
+) -> dict[str, Any]:
+    if state.runtime:
+        return state.runtime
+    try:
+        runtime_state = await asyncio.to_thread(create_runtime_func, project_root, None)
+        apply_runtime_state(state, runtime_state, shared_state_module)
+        state.runtime_init_error = None
+        return runtime_state
+    except Exception as exc:
+        state.runtime_init_error = str(exc)
+        log_json("WARN", "aura_server_runtime_init_failed", details={"error": state.runtime_init_error})
+        return {}
+
+
+async def resolve_runtime_component(
+    *,
+    state: RuntimeBootstrapState,
+    name: str,
+    ensure_runtime_initialized_func: Callable[[], Any],
+) -> Any:
+    component = getattr(state, name)
+    if component is not None:
+        return component
+    if not state.runtime:
+        await ensure_runtime_initialized_func()
+        component = getattr(state, name)
+        if component is not None:
+            return component
+    detail = f"{name} is not configured"
+    if state.runtime_init_error and not state.runtime:
+        detail = f"{detail}: {state.runtime_init_error}"
+    from fastapi import HTTPException  # noqa: PLC0415
+
+    raise HTTPException(status_code=503, detail=detail)
+
+
+def runtime_metrics_snapshot(
+    *,
+    state: RuntimeBootstrapState,
+    project_root: Path,
+    list_registered_services_func: Callable[[], list[Any]],
+    list_ai_environments_func: Callable[[Path], list[Any]],
+    build_run_tool_audit_summary_func: Callable[[Any], Any],
+) -> dict[str, Any]:
+    entries: list[Any] = []
+    if state.memory_store is not None and hasattr(state.memory_store, "read_log"):
+        try:
+            entries = list(state.memory_store.read_log(limit=1000) or [])
+        except Exception:
+            entries = []
+    return {
+        "total_calls": len(entries),
+        "registered_services": len(list_registered_services_func()),
+        "environment_count": len(list_ai_environments_func(project_root)),
+        "run_tool_audit": build_run_tool_audit_summary_func(state.memory_store),
+    }
+
+
+def load_model_config_status(project_root: Path) -> bool:
+    config_path = current_project_root(project_root) / "aura.config.json"
+    try:
+        if not config_path.exists():
+            return False
+        with open(config_path, encoding="utf-8") as handle:
+            cfg = json.load(handle)
+        return bool(
+            cfg.get("model_name")
+            or cfg.get("api_key")
+            or cfg.get("openai_api_key")
+            or cfg.get("local_model_profiles")
+        )
+    except Exception:
+        return False

--- a/aura_cli/server.py
+++ b/aura_cli/server.py
@@ -18,6 +18,16 @@ import re
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from aura_cli.api import state as _state
+from aura_cli.api.runtime_bootstrap import (
+    RuntimeBootstrapState,
+    apply_runtime_state as _bootstrap_apply_runtime_state,
+    current_project_root as _bootstrap_current_project_root,
+    ensure_runtime_initialized as _bootstrap_ensure_runtime_initialized,
+    load_model_config_status,
+    resolve_runtime_component as _bootstrap_resolve_runtime_component,
+    run_db_migrations as _bootstrap_run_db_migrations,
+    runtime_metrics_snapshot as _bootstrap_runtime_metrics_snapshot,
+)
 from core.logging_utils import log_json
 from core.mcp_contracts import (
     build_discovery_payload,
@@ -100,6 +110,7 @@ orchestrator = None
 model_adapter = None
 memory_store = None
 _runtime_init_error: str | None = None
+_bootstrap_state = RuntimeBootstrapState()
 
 RUN_TOOL_TIMEOUT_S = float(os.getenv("AURA_RUN_TOOL_TIMEOUT_S", "15"))
 RUN_TOOL_MAX_OUTPUT_BYTES = int(os.getenv("AURA_RUN_TOOL_MAX_OUTPUT_BYTES", str(64 * 1024)))
@@ -134,34 +145,25 @@ def _beads_runtime_snapshot():
     return {"enabled": False, "required": False, "scope": "none"}
 
 
+def _sync_runtime_state_from_exports() -> None:
+    _bootstrap_state.runtime = runtime
+    _bootstrap_state.orchestrator = orchestrator
+    _bootstrap_state.model_adapter = model_adapter
+    _bootstrap_state.memory_store = memory_store
+    _bootstrap_state.runtime_init_error = _runtime_init_error
+
+
+def _sync_runtime_exports() -> None:
+    global runtime, orchestrator, model_adapter, memory_store, _runtime_init_error
+    runtime = _bootstrap_state.runtime
+    orchestrator = _bootstrap_state.orchestrator
+    model_adapter = _bootstrap_state.model_adapter
+    memory_store = _bootstrap_state.memory_store
+    _runtime_init_error = _bootstrap_state.runtime_init_error
+
+
 def _run_db_migrations() -> None:
-    """Run auth and brain DB migrations idempotently before accepting requests."""
-    try:
-        from core.db_migrations import migrate_auth_db, migrate_brain_db  # noqa: PLC0415
-    except ImportError:  # pragma: no cover
-        log_json("WARN", "aura_db_migrations_unavailable", details={"reason": "core.db_migrations not importable"})
-        return
-
-    try:
-        from core.auth import _default_auth_db_path  # noqa: PLC0415
-    except ImportError:  # pragma: no cover
-
-        def _default_auth_db_path() -> Path:  # type: ignore[misc]
-            custom = os.environ.get("AURA_AUTH_DB_PATH")
-            if custom:
-                return Path(custom)
-            return Path.home() / ".local" / "share" / "aura" / "auth.db"
-
-    auth_db_path = Path(os.environ["AURA_AUTH_DB_PATH"]) if os.environ.get("AURA_AUTH_DB_PATH") else _default_auth_db_path()
-    brain_db_path = Path(os.environ.get("AURA_BRAIN_DB_PATH", "memory/brain_v2.db"))
-
-    auth_versions = migrate_auth_db(auth_db_path)
-    brain_versions = migrate_brain_db(brain_db_path)
-    log_json(
-        "INFO",
-        "aura_db_migrations_applied",
-        details={"auth_versions": auth_versions, "brain_versions": brain_versions},
-    )
+    _bootstrap_run_db_migrations(log_json)
 
 
 @asynccontextmanager
@@ -282,68 +284,49 @@ class WebhookPlanReviewRequest(BaseModel):
 
 
 def _current_project_root() -> Path:
-    configured_root = os.getenv("AURA_PROJECT_ROOT")
-    return Path(configured_root).resolve() if configured_root else PROJECT_ROOT.resolve()
+    return _bootstrap_current_project_root(PROJECT_ROOT)
 
 
 def _apply_runtime_state(runtime_state: Dict[str, Any]) -> None:
-    global runtime, orchestrator, model_adapter, memory_store
-    runtime = runtime_state
-    orchestrator = runtime_state.get("orchestrator")
-    model_adapter = runtime_state.get("model_adapter")
-    memory_store = runtime_state.get("memory_store")
-    # Sync to shared state module so routers always see the latest values.
-    _state.runtime = runtime
-    _state.orchestrator = orchestrator
-    _state.model_adapter = model_adapter
-    _state.memory_store = memory_store
+    _bootstrap_apply_runtime_state(_bootstrap_state, runtime_state, _state)
+    _sync_runtime_exports()
 
 
 async def _ensure_runtime_initialized() -> Dict[str, Any]:
-    global _runtime_init_error
-    if runtime:
-        return runtime
-    try:
-        from aura_cli.cli_main import create_runtime
+    _sync_runtime_state_from_exports()
+    from aura_cli.cli_main import create_runtime
 
-        runtime_state = await asyncio.to_thread(create_runtime, _current_project_root(), None)
-        _apply_runtime_state(runtime_state)
-        _runtime_init_error = None
-        return runtime_state
-    except Exception as exc:
-        _runtime_init_error = str(exc)
-        log_json("WARN", "aura_server_runtime_init_failed", details={"error": _runtime_init_error})
-        return {}
+    runtime_state = await _bootstrap_ensure_runtime_initialized(
+        state=_bootstrap_state,
+        project_root=_current_project_root(),
+        create_runtime_func=create_runtime,
+        shared_state_module=_state,
+        log_json=log_json,
+    )
+    _sync_runtime_exports()
+    return runtime_state
 
 
 async def _resolve_runtime_component(name: str) -> Any:
-    component = globals().get(name)
-    if component is not None:
-        return component
-    if not runtime:
-        await _ensure_runtime_initialized()
-        component = globals().get(name)
-        if component is not None:
-            return component
-    detail = f"{name} is not configured"
-    if _runtime_init_error and not runtime:
-        detail = f"{detail}: {_runtime_init_error}"
-    raise HTTPException(status_code=503, detail=detail)
+    _sync_runtime_state_from_exports()
+    result = await _bootstrap_resolve_runtime_component(
+        state=_bootstrap_state,
+        name=name,
+        ensure_runtime_initialized_func=_ensure_runtime_initialized,
+    )
+    _sync_runtime_exports()
+    return result
 
 
 def _runtime_metrics_snapshot() -> Dict[str, Any]:
-    entries: list[Any] = []
-    if memory_store is not None and hasattr(memory_store, "read_log"):
-        try:
-            entries = list(memory_store.read_log(limit=1000) or [])
-        except Exception:
-            entries = []
-    return {
-        "total_calls": len(entries),
-        "registered_services": len(list_registered_services()),
-        "environment_count": len(list_ai_environments(PROJECT_ROOT)),
-        "run_tool_audit": build_run_tool_audit_summary(memory_store),
-    }
+    _sync_runtime_state_from_exports()
+    return _bootstrap_runtime_metrics_snapshot(
+        state=_bootstrap_state,
+        project_root=PROJECT_ROOT,
+        list_registered_services_func=list_registered_services,
+        list_ai_environments_func=list_ai_environments,
+        build_run_tool_audit_summary_func=build_run_tool_audit_summary,
+    )
 
 
 def _clamped_run_tool_timeout_s() -> float:
@@ -789,15 +772,7 @@ async def ready():
         components["mcp_server"] = {"status": "unavailable", "latency_ms": None}
 
     # --- model_config ---
-    config_path = _current_project_root() / "aura.config.json"
-    model_configured = False
-    try:
-        if config_path.exists():
-            with open(config_path) as f:
-                cfg = json.load(f)
-            model_configured = bool(cfg.get("model_name") or cfg.get("api_key") or cfg.get("openai_api_key") or cfg.get("local_model_profiles"))
-    except Exception:
-        pass
+    model_configured = load_model_config_status(PROJECT_ROOT)
     components["model_config"] = {"status": "configured" if model_configured else "unconfigured"}
 
     # --- sandbox ---

--- a/tools/mcp_server.py
+++ b/tools/mcp_server.py
@@ -1,4 +1,4 @@
-"""Comprehensive MCP tool server for AURA CLI.
+"""Legacy compatibility MCP tool server for AURA CLI.
 
 Exposes a FastAPI application with a /call endpoint that dispatches to a
 rich set of developer tools: file I/O, linting, formatting, searching,
@@ -6,6 +6,9 @@ compression, git utilities, and more.
 
 Module-level flags (``ENABLE_WRITE``, ``ENABLE_RUN``, ``RUN_ALLOW``, etc.)
 can be overridden at runtime by tests via ``monkeypatch.setattr``.
+
+This module is a compatibility surface for older MCP utility workflows.
+The canonical dev-tools HTTP runtime is ``aura_cli.server``.
 """
 
 from __future__ import annotations
@@ -30,6 +33,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException, Request
 
 # R8: Import centralized MCP auth
 from tools.mcp_auth import is_auth_enabled, require_dev_tools_auth
+from tools.mcp_server_support import auth_mode_label, resolve_server_port
 from pydantic import BaseModel, Field
 
 # ---------------------------------------------------------------------------
@@ -127,7 +131,7 @@ async def _lifespan(application: FastAPI):
     yield
 
 
-app = FastAPI(title="AURA MCP Server", version="0.2.0", lifespan=_lifespan)
+app = FastAPI(title="AURA MCP Compatibility Server", version="0.2.0", lifespan=_lifespan)
 
 
 # ---------------------------------------------------------------------------
@@ -261,20 +265,9 @@ async def health(auth: str = Depends(require_dev_tools_auth)):
     auth_status = "enabled" if is_auth_enabled("dev_tools") else "disabled"
     return {
         "status": "ok",
+        "role": "compatibility",
+        "canonical_server": "aura_cli.server",
         "auth": auth_status,
-        "limits": {
-            "max_read_bytes": MAX_READ_BYTES,
-            "rate_limit_per_min": RATE_LIMIT_PER_MIN,
-            "compress_max_bytes": COMPRESS_MAX_BYTES,
-        },
-        "metrics": {
-            "enable_write": ENABLE_WRITE,
-            "enable_run": ENABLE_RUN,
-        },
-    }
-    """Return server health, current limits, and runtime metrics."""
-    return {
-        "status": "ok",
         "limits": {
             "max_read_bytes": MAX_READ_BYTES,
             "rate_limit_per_min": RATE_LIMIT_PER_MIN,
@@ -762,15 +755,7 @@ async def call_tool(req: CallRequest, auth: str = Depends(require_dev_tools_auth
 
 if __name__ == "__main__":
     import uvicorn
-    from core.config_manager import config as _cfg
-
-    # R4: port from config registry; env var PORT still overrides for backward-compat
-    port = int(os.getenv("PORT", _cfg.get_mcp_server_port("dev_tools")))
-
-    # R8: Log auth status on startup
-    from tools.mcp_auth import is_auth_enabled
-
-    auth_enabled = is_auth_enabled("dev_tools")
-    print(f"[MCP dev_tools] Starting on port {port} (auth: {'enabled' if auth_enabled else 'optional'})")
+    port = resolve_server_port("dev_tools")
+    print(f"[MCP dev_tools compatibility] Starting on port {port} (auth: {auth_mode_label('dev_tools')}); canonical server is aura_cli.server")
 
     uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- extract runtime bootstrap and state helpers into `aura_cli.api.runtime_bootstrap`
- keep `aura_cli.server` as the canonical dev-tools runtime entrypoint
- relabel `tools/mcp_server.py` and docs as the legacy compatibility surface

Closes #464