### PR TITLE
fix(mcp): repair runtime bootstrap state sync

### DIFF
--- a/aura_cli/api/runtime_bootstrap.py
+++ b/aura_cli/api/runtime_bootstrap.py
@@ -62,6 +62,7 @@ def apply_runtime_state(state: RuntimeBootstrapState, runtime_state: dict[str, A
     shared_state_module.orchestrator = state.orchestrator
     shared_state_module.model_adapter = state.model_adapter
     shared_state_module.memory_store = state.memory_store
+    shared_state_module._runtime_init_error = state.runtime_init_error
 
 
 async def ensure_runtime_initialized(
@@ -75,12 +76,13 @@ async def ensure_runtime_initialized(
     if state.runtime:
         return state.runtime
     try:
+        state.runtime_init_error = None
         runtime_state = await asyncio.to_thread(create_runtime_func, project_root, None)
         apply_runtime_state(state, runtime_state, shared_state_module)
-        state.runtime_init_error = None
         return runtime_state
     except Exception as exc:
         state.runtime_init_error = str(exc)
+        shared_state_module._runtime_init_error = state.runtime_init_error
         log_json("WARN", "aura_server_runtime_init_failed", details={"error": state.runtime_init_error})
         return {}
 
@@ -91,12 +93,12 @@ async def resolve_runtime_component(
     name: str,
     ensure_runtime_initialized_func: Callable[[], Any],
 ) -> Any:
-    component = getattr(state, name)
+    component = getattr(state, name, None)
     if component is not None:
         return component
     if not state.runtime:
         await ensure_runtime_initialized_func()
-        component = getattr(state, name)
+        component = getattr(state, name, None)
         if component is not None:
             return component
     detail = f"{name} is not configured"

--- a/tests/test_runtime_bootstrap.py
+++ b/tests/test_runtime_bootstrap.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from aura_cli.api.runtime_bootstrap import (
+    RuntimeBootstrapState,
+    apply_runtime_state,
+    ensure_runtime_initialized,
+    resolve_runtime_component,
+)
+
+
+def _shared_state() -> SimpleNamespace:
+    return SimpleNamespace(
+        runtime={},
+        orchestrator=None,
+        model_adapter=None,
+        memory_store=None,
+        _runtime_init_error="stale",
+    )
+
+
+def _log_json(*_args, **_kwargs) -> None:
+    return None
+
+
+def test_apply_runtime_state_syncs_shared_error_state():
+    state = RuntimeBootstrapState(runtime_init_error="boot failed")
+    orchestrator = object()
+    shared_state = _shared_state()
+
+    apply_runtime_state(
+        state,
+        {
+            "orchestrator": orchestrator,
+            "model_adapter": "model",
+            "memory_store": "memory",
+        },
+        shared_state,
+    )
+
+    assert shared_state.runtime == state.runtime
+    assert shared_state.orchestrator is orchestrator
+    assert shared_state.model_adapter == "model"
+    assert shared_state.memory_store == "memory"
+    assert shared_state._runtime_init_error == "boot failed"
+
+
+@pytest.mark.asyncio
+async def test_ensure_runtime_initialized_clears_shared_error_on_success():
+    state = RuntimeBootstrapState(runtime_init_error="old failure")
+    orchestrator = object()
+    shared_state = _shared_state()
+
+    def create_runtime(_project_root: Path, _config):
+        return {
+            "orchestrator": orchestrator,
+            "model_adapter": "model",
+            "memory_store": "memory",
+        }
+
+    result = await ensure_runtime_initialized(
+        state=state,
+        project_root=Path("/tmp/project"),
+        create_runtime_func=create_runtime,
+        shared_state_module=shared_state,
+        log_json=_log_json,
+    )
+
+    assert result["orchestrator"] is orchestrator
+    assert state.runtime_init_error is None
+    assert shared_state._runtime_init_error is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_runtime_initialized_publishes_failure_to_shared_state():
+    state = RuntimeBootstrapState()
+    shared_state = _shared_state()
+
+    def create_runtime(_project_root: Path, _config):
+        raise RuntimeError("runtime boot failed")
+
+    result = await ensure_runtime_initialized(
+        state=state,
+        project_root=Path("/tmp/project"),
+        create_runtime_func=create_runtime,
+        shared_state_module=shared_state,
+        log_json=_log_json,
+    )
+
+    assert result == {}
+    assert state.runtime_init_error == "runtime boot failed"
+    assert shared_state._runtime_init_error == "runtime boot failed"
+
+
+@pytest.mark.asyncio
+async def test_resolve_runtime_component_invalid_name_returns_503():
+    state = RuntimeBootstrapState(runtime_init_error="runtime boot failed")
+
+    async def ensure_runtime_initialized_func():
+        return {}
+
+    with pytest.raises(HTTPException, match="not_real is not configured: runtime boot failed"):
+        await resolve_runtime_component(
+            state=state,
+            name="not_real",
+            ensure_runtime_initialized_func=ensure_runtime_initialized_func,
+        )


### PR DESCRIPTION
## Summary
- synchronize `_runtime_init_error` into shared API state during bootstrap updates
- preserve 503 behavior for unknown runtime component names
- add direct tests for extracted runtime bootstrap logic

Closes #466